### PR TITLE
[Design/#47] home, cogo 디자인 수정

### DIFF
--- a/lib/common/widgets/custom_box.dart
+++ b/lib/common/widgets/custom_box.dart
@@ -1,3 +1,5 @@
+import 'package:cogo/common/widgets/atoms/texts/texts.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 
 class InfoBox extends StatelessWidget {
@@ -9,7 +11,7 @@ class InfoBox extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Container(
-      width: width, // width 파라미터 사용
+      width: width,
       height: 50,
       alignment: Alignment.center,
       decoration: BoxDecoration(
@@ -18,11 +20,7 @@ class InfoBox extends StatelessWidget {
       ),
       child: Text(
         info,
-        style: const TextStyle(
-          color: Colors.white,
-          fontFamily: 'PretendardMedium',
-          fontSize: 18,
-        ),
+        style: CogoTextStyle.body18.copyWith(color: CogoColor.white50),
       ),
     );
   }

--- a/lib/common/widgets/custom_button.dart
+++ b/lib/common/widgets/custom_button.dart
@@ -4,36 +4,36 @@ class CustomButton extends StatelessWidget {
   final String text;
   final bool isSelected;
   final VoidCallback? onPressed;
+  final double? width;
 
-  CustomButton({
+  const CustomButton({
+    Key? key,
     required this.text,
     required this.isSelected,
-    required this.onPressed,
-  });
+    this.onPressed,
+    this.width,
+  }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    return Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 5.0),
-        child: SizedBox(
-          height: 50,
-          child: ElevatedButton(
-            onPressed: onPressed,
-            style: ElevatedButton.styleFrom(
-              backgroundColor: isSelected ? Colors.black : Colors.grey[300],
-              foregroundColor: isSelected ? Colors.white : Colors.black,
-              textStyle: const TextStyle(
-                fontFamily: 'PretendardMedium',
-                fontSize: 18,
-              ),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(20),
-              ),
-            ),
-            child: Text(text),
+    return SizedBox(
+      width: width,
+      height: 50,
+      child: ElevatedButton(
+        onPressed: isSelected ? onPressed : null,
+        style: ElevatedButton.styleFrom(
+          backgroundColor: isSelected ? Colors.black : Colors.grey[300],
+          foregroundColor: isSelected ? Colors.white : Colors.black,
+          shape: RoundedRectangleBorder(
+            borderRadius: BorderRadius.circular(20),
+          ),
+          textStyle: const TextStyle(
+            fontFamily: 'PretendardMedium',
+            fontSize: 18,
           ),
         ),
-
+        child: Text(text),
+      ),
     );
   }
 }

--- a/lib/common/widgets/custom_button.dart
+++ b/lib/common/widgets/custom_button.dart
@@ -1,3 +1,5 @@
+import 'package:cogo/common/widgets/widgets.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 
 class CustomButton extends StatelessWidget {
@@ -22,16 +24,13 @@ class CustomButton extends StatelessWidget {
       child: ElevatedButton(
         onPressed: isSelected ? onPressed : null,
         style: ElevatedButton.styleFrom(
-          backgroundColor: isSelected ? Colors.black : Colors.grey[300],
-          foregroundColor: isSelected ? Colors.white : Colors.black,
-          shape: RoundedRectangleBorder(
-            borderRadius: BorderRadius.circular(20),
-          ),
-          textStyle: const TextStyle(
-            fontFamily: 'PretendardMedium',
-            fontSize: 18,
-          ),
-        ),
+            backgroundColor:
+                isSelected ? CogoColor.main : CogoColor.systemGray02,
+            foregroundColor: isSelected ? CogoColor.white50 : CogoColor.main,
+            shape: RoundedRectangleBorder(
+              borderRadius: BorderRadius.circular(20),
+            ),
+            textStyle: CogoTextStyle.body18),
         child: Text(text),
       ),
     );

--- a/lib/common/widgets/date_picker.dart
+++ b/lib/common/widgets/date_picker.dart
@@ -1,64 +1,46 @@
+import 'package:cogo/common/widgets/atoms/texts/styles.dart';
+import 'package:cogo/constants/colors.dart';
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class DatePicker extends StatelessWidget {
-  final DateTime selectedDate;
-  final ValueChanged<DateTime> onDateSelected;
+  final DateTime date;
+  final DateTime day;
 
   const DatePicker({
     Key? key,
-    required this.selectedDate,
-    required this.onDateSelected,
+    required this.date,
+    required this.day,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final now = DateTime.now();
     final dateFormat = DateFormat('dd');
     final dayFormat = DateFormat('E', 'ko');
 
-    return SizedBox(
-      height: 100,
-      child: ListView.builder(
-        scrollDirection: Axis.horizontal,
-        itemCount: 7,
-        itemBuilder: (context, index) {
-          final date = now.add(Duration(days: index));
-          final isSelected = date.day == selectedDate.day;
-
-          return GestureDetector(
-            onTap: () => onDateSelected(date),
-            child: Container(
-              width: 60,
-              margin: const EdgeInsets.symmetric(horizontal: 5.0),
-              decoration: BoxDecoration(
-                color: isSelected ? Colors.black : const Color(0xFFEDEDED),
-                shape: BoxShape.circle,
-              ),
-              child: Column(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Text(
-                    dateFormat.format(date),
-                    style: TextStyle(
-                      fontSize: 18,
-                      fontFamily: 'PretendardMedium',
-                      color: isSelected ? Colors.white : const Color(0xFF6E6E6E),
-                    ),
-                  ),
-                  Text(
-                    dayFormat.format(date),
-                    style: TextStyle(
-                      fontSize: 12,
-                      fontFamily: 'PretendardMedium',
-                      color: isSelected ? Colors.white : Colors.black,
-                    ),
-                  ),
-                ],
-              ),
+    return Container(
+      width: 55,
+      margin: const EdgeInsets.symmetric(horizontal: 5.0),
+      decoration: const BoxDecoration(
+        color: CogoColor.main,
+        shape: BoxShape.circle,
+      ),
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Text(
+            dateFormat.format(date),
+            style: CogoTextStyle.body18.copyWith(
+              color: CogoColor.white50,
             ),
-          );
-        },
+          ),
+          Text(
+            dayFormat.format(date),
+            style: CogoTextStyle.body9.copyWith(
+              color: CogoColor.white50,
+            ),
+          ),
+        ],
       ),
     );
   }

--- a/lib/common/widgets/date_picker.dart
+++ b/lib/common/widgets/date_picker.dart
@@ -22,7 +22,7 @@ class DatePicker extends StatelessWidget {
       width: 55,
       margin: const EdgeInsets.symmetric(horizontal: 5.0),
       decoration: const BoxDecoration(
-        color: CogoColor.main,
+        color: CogoColor.systemGray05,
         shape: BoxShape.circle,
       ),
       child: Column(

--- a/lib/common/widgets/header.dart
+++ b/lib/common/widgets/header.dart
@@ -1,3 +1,5 @@
+import 'package:cogo/common/widgets/widgets.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
 
@@ -31,23 +33,11 @@ class Header extends StatelessWidget {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              Text(
-                title,
-                style: const TextStyle(
-                  fontSize: 18,
-                  fontFamily: 'PretendardMedium',
-                  color: Colors.black,
-                ),
-              ),
+              Text(title, style: CogoTextStyle.body18),
               const SizedBox(height: 4),
-              Text(
-                subtitle,
-                style: const TextStyle(
-                  fontSize: 12,
-                  fontFamily: 'PretendardMedium',
-                  color: Colors.grey,
-                ),
-              ),
+              Text(subtitle,
+                  style: CogoTextStyle.body12
+                      .copyWith(color: CogoColor.systemGray03)),
             ],
           ),
         ),

--- a/lib/common/widgets/horizontal_button_list.dart
+++ b/lib/common/widgets/horizontal_button_list.dart
@@ -1,10 +1,13 @@
+import 'package:cogo/common/widgets/widgets.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 
 class HorizontalButtonList extends StatefulWidget {
   final List<String> buttonTitles;
   final ValueChanged<String> onButtonPressed;
 
-  const HorizontalButtonList({super.key, required this.buttonTitles, required this.onButtonPressed});
+  const HorizontalButtonList(
+      {super.key, required this.buttonTitles, required this.onButtonPressed});
 
   @override
   _HorizontalButtonListState createState() => _HorizontalButtonListState();
@@ -17,7 +20,10 @@ class _HorizontalButtonListState extends State<HorizontalButtonList> {
   Widget build(BuildContext context) {
     double totalPadding = 40;
     double buttonPadding = 5;
-    double buttonWidth = (MediaQuery.of(context).size.width - totalPadding - (buttonPadding * (widget.buttonTitles.length - 1))) / widget.buttonTitles.length;
+    double buttonWidth = (MediaQuery.of(context).size.width -
+            totalPadding -
+            (buttonPadding * (widget.buttonTitles.length - 1))) /
+        widget.buttonTitles.length;
     return SingleChildScrollView(
       scrollDirection: Axis.horizontal,
       child: Container(
@@ -25,9 +31,10 @@ class _HorizontalButtonListState extends State<HorizontalButtonList> {
         child: Row(
           children: widget.buttonTitles
               .map((title) => Padding(
-            padding: EdgeInsets.symmetric(horizontal: buttonPadding / 2),
-            child: _buildFieldButton(context, title, buttonWidth),
-          ))
+                    padding:
+                        EdgeInsets.symmetric(horizontal: buttonPadding / 2),
+                    child: _buildFieldButton(context, title, buttonWidth),
+                  ))
               .toList(),
         ),
       ),
@@ -46,16 +53,14 @@ class _HorizontalButtonListState extends State<HorizontalButtonList> {
           widget.onButtonPressed(title);
         },
         style: ElevatedButton.styleFrom(
-          backgroundColor: isSelected ? Colors.black : Colors.white,
-          foregroundColor: isSelected ? Colors.white : Colors.black,
-          textStyle: const TextStyle(
-            fontFamily: 'PretendardMedium',
-            fontSize: 12,
-
-          ),
+          backgroundColor:
+              isSelected ? CogoColor.systemGray05 : CogoColor.white50,
+          foregroundColor:
+              isSelected ? CogoColor.white50 : CogoColor.systemGray05,
+          textStyle: CogoTextStyle.body12,
           shape: RoundedRectangleBorder(
             borderRadius: BorderRadius.circular(20),
-            side: BorderSide(color: Colors.grey[300]!),
+            side: const BorderSide(color: CogoColor.systemGray03),
           ),
           elevation: 0,
         ),

--- a/lib/common/widgets/horizontal_date_picker.dart
+++ b/lib/common/widgets/horizontal_date_picker.dart
@@ -1,0 +1,119 @@
+import 'package:cogo/common/widgets/widgets.dart';
+import 'package:cogo/constants/constants.dart';
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+
+class HorizontalDatePicker extends StatelessWidget {
+  final DateTime selectedDate;
+  final ValueChanged<DateTime> onDateSelected;
+  final int itemCount;
+
+  const HorizontalDatePicker({
+    super.key,
+    required this.selectedDate,
+    required this.onDateSelected,
+    required this.itemCount,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final now = DateTime.now();
+    bool addedExtraContainer = false;
+
+    return SizedBox(
+      height: 80,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        itemCount: itemCount,
+        itemBuilder: (context, index) {
+          final date = now.add(Duration(days: index));
+          final isSelected = date.day == selectedDate.day;
+
+          final isLastDayOfMonth =
+              date.month != date.add(const Duration(days: 1)).month;
+
+          if (isLastDayOfMonth && !addedExtraContainer) {
+            addedExtraContainer = true;
+            return Row(
+              children: [
+                _buildDateContainer(date, isSelected, isLastDayOfMonth, index),
+                _buildNewContainer(date),
+              ],
+            );
+          }
+
+          return _buildDateContainer(date, isSelected, isLastDayOfMonth, index);
+        },
+      ),
+    );
+  }
+
+  Widget _buildDateContainer(
+      DateTime date, bool isSelected, bool isLastDayOfMonth, int index) {
+    final dateFormat = DateFormat('dd');
+    final dayFormat = DateFormat('E', 'ko');
+
+    return GestureDetector(
+      onTap: () => onDateSelected(date),
+      child: Container(
+        width: 55,
+        margin: const EdgeInsets.symmetric(horizontal: 5.0),
+        decoration: BoxDecoration(
+          color: isSelected ? CogoColor.main : CogoColor.systemGray02,
+          shape: BoxShape.circle,
+        ),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              dateFormat.format(date),
+              style: CogoTextStyle.body18.copyWith(
+                color: isSelected ? CogoColor.white50 : CogoColor.systemGray04,
+              ),
+            ),
+            Text(
+              index == 0 ? '오늘' : dayFormat.format(date),
+              style: CogoTextStyle.body9.copyWith(
+                color: isSelected ? CogoColor.white50 : CogoColor.main,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildNewContainer(DateTime date) {
+    final yearFormat = DateFormat('yyyy');
+    final monthFormat = DateFormat('M월');
+    final nextMonthDate = DateTime(date.year, date.month + 1, 1);
+
+    return Container(
+      width: 55,
+      decoration: BoxDecoration(
+        color: CogoColor.white50,
+        shape: BoxShape.circle,
+        border: Border.all(color: CogoColor.systemGray03, width: 0.7),
+      ),
+      child: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Text(
+              yearFormat.format(date),
+              style: CogoTextStyle.body9.copyWith(
+                color: CogoColor.systemGray03,
+              ),
+            ),
+            Text(
+              monthFormat.format(nextMonthDate),
+              style: CogoTextStyle.body14.copyWith(
+                color: CogoColor.systemGray03,
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/common/widgets/horizontal_date_picker.dart
+++ b/lib/common/widgets/horizontal_date_picker.dart
@@ -59,7 +59,7 @@ class HorizontalDatePicker extends StatelessWidget {
         width: 55,
         margin: const EdgeInsets.symmetric(horizontal: 5.0),
         decoration: BoxDecoration(
-          color: isSelected ? CogoColor.main : CogoColor.systemGray02,
+          color: isSelected ? CogoColor.systemGray05 : CogoColor.systemGray02,
           shape: BoxShape.circle,
         ),
         child: Column(
@@ -74,7 +74,7 @@ class HorizontalDatePicker extends StatelessWidget {
             Text(
               index == 0 ? '오늘' : dayFormat.format(date),
               style: CogoTextStyle.body9.copyWith(
-                color: isSelected ? CogoColor.white50 : CogoColor.main,
+                color: isSelected ? CogoColor.white50 : CogoColor.systemGray05,
               ),
             ),
           ],

--- a/lib/common/widgets/mentor_profile_dialog.dart
+++ b/lib/common/widgets/mentor_profile_dialog.dart
@@ -10,12 +10,12 @@ class MentorProfileDialog extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final double screenWidth = MediaQuery.of(context).size.width;
-    final double dialogWidth = screenWidth - 40;  // 전체 화면 너비에서 20을 뺀 값
-    final double dialogHeight = dialogWidth;  // 너비와 높이를 동일하게 설정
+    final double dialogWidth = screenWidth - 40; // 전체 화면 너비에서 20을 뺀 값
+    final double dialogHeight = dialogWidth;
 
     return Dialog(
       backgroundColor: Colors.white,
-      insetPadding: const EdgeInsets.all(10), // 모든 방향에서 10의 패딩 적용
+      insetPadding: const EdgeInsets.all(10),
       shape: RoundedRectangleBorder(
         borderRadius: BorderRadius.circular(20.0),
       ),
@@ -23,7 +23,7 @@ class MentorProfileDialog extends StatelessWidget {
         width: dialogWidth,
         height: dialogHeight,
         child: Stack(
-          clipBehavior: Clip.none, // Stack 바깥으로 나가는 것을 허용
+          clipBehavior: Clip.none,
           children: [
             Padding(
               padding: const EdgeInsets.all(20),
@@ -53,11 +53,12 @@ class MentorProfileDialog extends StatelessWidget {
                     onPressed: () => Navigator.of(context).push(_createRoute()),
                     style: ElevatedButton.styleFrom(
                       backgroundColor: CogoColor.systemGray05,
-                      minimumSize: Size(dialogWidth, 50),  // 버튼의 너비를 다이얼로그 너비에 맞춤
+                      minimumSize: Size(dialogWidth, 50),
                     ),
                     child: Text(
                       '멘토 프로필 작성하기',
-                      style: CogoTextStyle.button1.copyWith(color: CogoColor.white50),
+                      style: CogoTextStyle.button1
+                          .copyWith(color: CogoColor.white50),
                     ),
                   ),
                 ],
@@ -65,7 +66,7 @@ class MentorProfileDialog extends StatelessWidget {
             ),
             // 닫기 버튼
             Positioned(
-              top: -50,  // 다이얼로그 외부에 위치
+              top: -50,
               right: 0,
               child: GestureDetector(
                 onTap: () => Navigator.of(context).pop(),
@@ -84,9 +85,11 @@ class MentorProfileDialog extends StatelessWidget {
 
   Route _createRoute() {
     return PageRouteBuilder(
-      pageBuilder: (context, animation, secondaryAnimation) => const MentorIntroductionScreen(),
+      pageBuilder: (context, animation, secondaryAnimation) =>
+          const MentorIntroductionScreen(),
       transitionsBuilder: (context, animation, secondaryAnimation, child) {
-        var tween = Tween(begin: const Offset(0.0, 1.0), end: Offset.zero).chain(CurveTween(curve: Curves.ease));
+        var tween = Tween(begin: const Offset(0.0, 1.0), end: Offset.zero)
+            .chain(CurveTween(curve: Curves.ease));
         return SlideTransition(
           position: animation.drive(tween),
           child: child,

--- a/lib/common/widgets/profile_card.dart
+++ b/lib/common/widgets/profile_card.dart
@@ -1,6 +1,7 @@
 import 'package:cogo/common/widgets/atoms/texts/texts.dart';
 import 'package:cogo/common/widgets/tag_list.dart';
 import 'package:flutter/material.dart';
+import 'package:cogo/constants/constants.dart';
 
 class ProfileCard extends StatelessWidget {
   final String picture;
@@ -36,7 +37,7 @@ class ProfileCard extends StatelessWidget {
         width: width,
         height: height,
         decoration: BoxDecoration(
-          color: Colors.white,
+          color: CogoColor.white50,
           borderRadius: BorderRadius.circular(20),
           boxShadow: [
             BoxShadow(
@@ -50,7 +51,6 @@ class ProfileCard extends StatelessWidget {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            // 이미지와 태그를 겹쳐서 배치하기 위한 Stack 사용
             Stack(
               children: [
                 ClipRRect(
@@ -61,14 +61,13 @@ class ProfileCard extends StatelessWidget {
                   child: Image.asset(
                     picture.isNotEmpty ? picture : 'assets/default_img.png',
                     width: double.infinity,
-                    height: 150, // 이미지 높이
-                    fit: BoxFit.cover, // 이미지 꽉 채우기
+                    height: 150,
+                    fit: BoxFit.cover,
                   ),
                 ),
-                // 클럽과 파트 값을 이미지 위에 배치
                 Positioned(
-                  top: 15, // 이미지 위에서 10px 아래에 배치
-                  left: 15, // 이미지 왼쪽에서 10px 오른쪽에 배치
+                  top: 15,
+                  left: 15,
                   child: TagList(tags: tags), // 태그 리스트를 새로운 위젯으로 교체
                 ),
               ],

--- a/lib/common/widgets/time_picker.dart
+++ b/lib/common/widgets/time_picker.dart
@@ -1,55 +1,53 @@
+import 'package:cogo/common/widgets/atoms/texts/styles.dart';
+import 'package:cogo/constants/colors.dart';
 import 'package:flutter/material.dart';
 
 class TimePicker extends StatelessWidget {
   final int selectedTimeSlot;
   final ValueChanged<int> onTimeSlotSelected;
+  final List<String> timeSlots;
 
   const TimePicker({
     Key? key,
     required this.selectedTimeSlot,
     required this.onTimeSlotSelected,
+    required this.timeSlots,
   }) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
-    final timeSlots = [
-      '09:00 ~ 10:00',
-      '10:00 ~ 11:00',
-      '11:00 ~ 12:00',
-      '13:00 ~ 14:00',
-      '14:00 ~ 15:00',
-      '15:00 ~ 16:00',
-    ];
+    return Center(
+      child: Wrap(
+        spacing: 10.0,
+        runSpacing: 15.0,
+        children: List.generate(timeSlots.length, (index) {
+          final isSelected = index == selectedTimeSlot;
 
-    return Wrap(
-      spacing: 8.0,
-      runSpacing: 15.0,
-      children: List.generate(timeSlots.length, (index) {
-        final isSelected = index == selectedTimeSlot;
-
-        return GestureDetector(
-          onTap: () => onTimeSlotSelected(index),
-          child: Container(
-            padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
-            decoration: BoxDecoration(
-              color: isSelected ? Colors.black : Colors.white,
-              borderRadius: BorderRadius.circular(20),
-              border: Border.all(
-                color: const Color(0xFFE2E2E2),
-                width: 1.0,
+          return GestureDetector(
+            onTap: () => onTimeSlotSelected(index),
+            child: Container(
+              width: 105,
+              height: 25,
+              alignment: Alignment.center,
+              decoration: BoxDecoration(
+                color: isSelected ? Colors.black : Colors.white,
+                borderRadius: BorderRadius.circular(20),
+                border: Border.all(
+                  color: CogoColor.systemGray03,
+                  width: 0.7,
+                ),
+              ),
+              child: Text(
+                timeSlots[index],
+                style: CogoTextStyle.body12.copyWith(
+                    color: isSelected
+                        ? CogoColor.white50
+                        : CogoColor.systemGray03),
               ),
             ),
-            child: Text(
-              timeSlots[index],
-              style: TextStyle(
-                color: isSelected ? Colors.white : Colors.black,
-                fontFamily: 'PretendardMedium',
-                fontSize: 12,
-              ),
-            ),
-          ),
-        );
-      }),
+          );
+        }),
+      ),
     );
   }
 }

--- a/lib/common/widgets/time_picker.dart
+++ b/lib/common/widgets/time_picker.dart
@@ -3,14 +3,14 @@ import 'package:cogo/constants/colors.dart';
 import 'package:flutter/material.dart';
 
 class TimePicker extends StatelessWidget {
-  final int selectedTimeSlot;
-  final ValueChanged<int> onTimeSlotSelected;
+  final int? selectedTimeSlot;
+  final ValueChanged<int>? onTimeSlotSelected;
   final List<String> timeSlots;
 
   const TimePicker({
     Key? key,
-    required this.selectedTimeSlot,
-    required this.onTimeSlotSelected,
+    this.selectedTimeSlot, // Make selectedTimeSlot optional
+    this.onTimeSlotSelected, // Make onTimeSlotSelected optional
     required this.timeSlots,
   }) : super(key: key);
 
@@ -21,10 +21,13 @@ class TimePicker extends StatelessWidget {
         spacing: 10.0,
         runSpacing: 15.0,
         children: List.generate(timeSlots.length, (index) {
-          final isSelected = index == selectedTimeSlot;
+          final isSelected =
+              selectedTimeSlot != null && index == selectedTimeSlot;
 
           return GestureDetector(
-            onTap: () => onTimeSlotSelected(index),
+            onTap: onTimeSlotSelected != null
+                ? () => onTimeSlotSelected!(index)
+                : null,
             child: Container(
               width: 105,
               height: 25,
@@ -40,9 +43,9 @@ class TimePicker extends StatelessWidget {
               child: Text(
                 timeSlots[index],
                 style: CogoTextStyle.body12.copyWith(
-                    color: isSelected
-                        ? CogoColor.white50
-                        : CogoColor.systemGray03),
+                  color:
+                      isSelected ? CogoColor.white50 : CogoColor.systemGray03,
+                ),
               ),
             ),
           );

--- a/lib/common/widgets/time_picker.dart
+++ b/lib/common/widgets/time_picker.dart
@@ -9,8 +9,8 @@ class TimePicker extends StatelessWidget {
 
   const TimePicker({
     Key? key,
-    this.selectedTimeSlot, // Make selectedTimeSlot optional
-    this.onTimeSlotSelected, // Make onTimeSlotSelected optional
+    this.selectedTimeSlot,
+    this.onTimeSlotSelected,
     required this.timeSlots,
   }) : super(key: key);
 
@@ -33,7 +33,7 @@ class TimePicker extends StatelessWidget {
               height: 25,
               alignment: Alignment.center,
               decoration: BoxDecoration(
-                color: isSelected ? Colors.black : Colors.white,
+                color: isSelected ? CogoColor.systemGray05 : CogoColor.white50,
                 borderRadius: BorderRadius.circular(20),
                 border: Border.all(
                   color: CogoColor.systemGray03,

--- a/lib/common/widgets/widgets.dart
+++ b/lib/common/widgets/widgets.dart
@@ -6,5 +6,6 @@ export 'profile_card.dart';
 export 'mentor_profile_dialog.dart';
 export 'atoms/texts/texts.dart';
 export 'date_picker.dart';
+export 'horizontal_date_picker.dart';
 export 'time_picker.dart';
 export 'custom_textfield_with_counter.dart';

--- a/lib/features/cogo/views/mentee/cogo_screen.dart
+++ b/lib/features/cogo/views/mentee/cogo_screen.dart
@@ -1,6 +1,8 @@
+import 'package:cogo/constants/colors.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cogo/features/cogo/view_models/mentee/cogo_view_model.dart';
+import 'package:cogo/common/widgets/widgets.dart';
 
 class CogoScreen extends StatelessWidget {
   const CogoScreen({super.key});
@@ -21,21 +23,15 @@ class CogoScreen extends StatelessWidget {
                   padding: EdgeInsets.only(left: 15.0),
                   child: Text(
                     '내 코고함',
-                    style: TextStyle(
-                      fontFamily: 'PretendardMedium',
-                      fontSize: 22,
-                    ),
+                    style: CogoTextStyle.body18,
                   ),
                 ),
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 16.0),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
                   child: Text(
                     'COGO를 하면서 많은 성장을 기원해요!',
-                    style: TextStyle(
-                      fontFamily: 'PretendardMedium',
-                      fontSize: 12,
-                      color: Color(0xFFAEAEB2),
-                    ),
+                    style: CogoTextStyle.body12
+                        .copyWith(color: CogoColor.systemGray03),
                   ),
                 ),
                 const SizedBox(height: 20),
@@ -46,10 +42,7 @@ class CogoScreen extends StatelessWidget {
                         ListTile(
                           title: const Text(
                             '받은 코고',
-                            style: TextStyle(
-                              fontFamily: 'PretendardMedium',
-                              fontSize: 18,
-                            ),
+                            style: CogoTextStyle.body16,
                           ),
                           trailing: const Icon(Icons.chevron_right),
                           onTap: () {
@@ -62,10 +55,7 @@ class CogoScreen extends StatelessWidget {
                         ListTile(
                           title: const Text(
                             '성사된 코고',
-                            style: TextStyle(
-                              fontFamily: 'PretendardMedium',
-                              fontSize: 18,
-                            ),
+                            style: CogoTextStyle.body16,
                           ),
                           trailing: const Icon(Icons.chevron_right),
                           onTap: () {

--- a/lib/features/cogo/views/mentee/sended_cogo_detail_screen.dart
+++ b/lib/features/cogo/views/mentee/sended_cogo_detail_screen.dart
@@ -1,7 +1,7 @@
+import 'package:cogo/common/widgets/widgets.dart';
+import 'package:cogo/features/cogo/view_models/mentee/sended_cogo_detail_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:cogo/features/cogo/view_models/mentee/sended_cogo_detail_view_model.dart';
-import 'package:cogo/common/widgets/header.dart';
 
 class SendedCogoDetailScreen extends StatelessWidget {
   const SendedCogoDetailScreen({super.key});
@@ -10,152 +10,87 @@ class SendedCogoDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
       create: (_) => SendedCogoDetailViewModel(),
-      child: Scaffold(
-        backgroundColor: Colors.white,
-        body: SafeArea(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Expanded(
-                child: SingleChildScrollView(
-                  child: Padding(
-                    padding: const EdgeInsets.only(top: 5.0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.only(left: 15.0),
-                          child: Header(
-                            title: '김지은님이 코고신청을 보냈어요',
-                            subtitle: 'COGO를 하면서 많은 성장을 기원해요!',
-                            onBackButtonPressed: () => Navigator.of(context).pop(),
-                          ),
-                        ),
-                        const SizedBox(height: 20),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-                          child: ConstrainedBox(
-                            constraints: const BoxConstraints(
-                              minWidth: 0,
-                              maxWidth: double.infinity,
-                            ),
-                            child: IntrinsicWidth(
-                              child: Container(
-                                padding: const EdgeInsets.all(16.0),
-                                decoration: BoxDecoration(
-                                  color: const Color(0xFFF7F7F7),
-                                  borderRadius: BorderRadius.circular(20),
-                                ),
-                                child: const Text(
-                                  '안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구...',
-                                  style: TextStyle(
-                                    fontFamily: 'PretendardMedium',
-                                    fontSize: 12,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 20),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              _buildDateBox(context, '7/31'),
-                              _buildDateBox(context, '8/3'),
-                              _buildDateBox(context, '9/9'),
-                            ],
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 10.0),
-                          child: Consumer<SendedCogoDetailViewModel>(
-                            builder: (context, viewModel, child) {
-                              return Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                children: [
-                                  _buildTimeSlotButton(context, '09:00 ~ 10:00', 0, viewModel),
-                                  _buildTimeSlotButton(context, '10:00 ~ 11:00', 1, viewModel),
-                                  _buildTimeSlotButton(context, '11:00 ~ 12:00', 2, viewModel),
-                                ],
-                              );
-                            },
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ],
+      builder: (context, child) {
+        return Scaffold(
+          backgroundColor: Colors.white,
+          body: SafeArea(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(child: _buildContent(context)),
+              ],
+            ),
           ),
-        ),
+        );
+      },
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.only(top: 5.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildHeader(context),
+          const SizedBox(height: 20),
+          _buildMessageContainer(),
+          _buildDateAndTimePicker(),
+        ],
       ),
     );
   }
 
-  Widget _buildDateBox(BuildContext context, String date) {
-    return Expanded(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 5.0),
+  Widget _buildHeader(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 15.0),
+      child: Header(
+        title: '김지은님이 코고신청을 보냈어요',
+        subtitle: 'COGO를 하면서 많은 성장을 기원해요!',
+        onBackButtonPressed: () => Navigator.of(context).pop(),
+      ),
+    );
+  }
+
+  Widget _buildMessageContainer() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 15.0),
+      child: IntrinsicWidth(
         child: Container(
-          height: 50,
-          decoration: const BoxDecoration(
-            color: Colors.black,
-            shape: BoxShape.circle,
+          padding: const EdgeInsets.all(16.0),
+          decoration: BoxDecoration(
+            color: const Color(0xFFF7F7F7),
+            borderRadius: BorderRadius.circular(20),
           ),
-          alignment: Alignment.center,
-          child: Text(
-            date,
-            style: const TextStyle(
-              color: Colors.white,
-              fontFamily: 'PretendardMedium',
-              fontSize: 14,
-            ),
+          child: const Text(
+            '안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구 안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구 안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구 안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구',
+            style: CogoTextStyle.body12,
           ),
         ),
       ),
     );
   }
 
-  Widget _buildTimeSlotButton(
-      BuildContext context, String text, int index, SendedCogoDetailViewModel viewModel) {
-    final bool isSelected = index == viewModel.selectedTimeSlotIndex;
-
-    return Expanded(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 5.0),
-        child: SizedBox(
-          height: 30,
-          child: ElevatedButton(
-            onPressed: () {
-              viewModel.selectTimeSlot(index);
-            },
-            style: ElevatedButton.styleFrom(
-              padding: const EdgeInsets.symmetric(vertical: 0),
-              backgroundColor: isSelected ? Colors.black : Colors.white,
-              foregroundColor: isSelected ? Colors.white : const Color(0xFF8F8F8F),
-              elevation: 0,
-              textStyle: const TextStyle(
-                fontFamily: 'PretendardMedium',
-                fontSize: 12,
-              ),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(20),
-                side: const BorderSide(color: Colors.grey),
-              ),
-            ),
-            child: Text(
-              text,
-              style: TextStyle(
-                color: isSelected ? Colors.white : const Color(0xFF8F8F8F),
-              ),
+  Widget _buildDateAndTimePicker() {
+    return Consumer<SendedCogoDetailViewModel>(
+      builder: (context, viewModel, child) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 15.0),
+          child: SizedBox(
+            height: 100,
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              children: [
+                DatePicker(date: DateTime.now(), day: DateTime.now()),
+                const SizedBox(width: 5),
+                TimePicker(
+                  timeSlots: ['09:00 ~ 10:00'],
+                ),
+              ],
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/features/cogo/views/mentee/sended_cogo_screen.dart
+++ b/lib/features/cogo/views/mentee/sended_cogo_screen.dart
@@ -1,3 +1,5 @@
+import 'package:cogo/common/widgets/atoms/texts/styles.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cogo/features/cogo/view_models/mentee/sended_cogo_view_model.dart';
@@ -45,23 +47,14 @@ class SendedCogoScreen extends StatelessWidget {
                                 borderRadius: BorderRadius.circular(20),
                               ),
                               child: Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
-                                  Text(
-                                    item['title']!,
-                                    style: const TextStyle(
-                                      fontFamily: 'PretendardMedium',
-                                      fontSize: 16,
-                                    ),
-                                  ),
-                                  Text(
-                                    item['date']!,
-                                    style: const TextStyle(
-                                      fontFamily: 'PretendardMedium',
-                                      fontSize: 12,
-                                      color: Colors.grey,
-                                    ),
-                                  ),
+                                  Text(item['title']!,
+                                      style: CogoTextStyle.body16),
+                                  Text(item['date']!,
+                                      style: CogoTextStyle.body12.copyWith(
+                                          color: CogoColor.systemGray03)),
                                 ],
                               ),
                             ),

--- a/lib/features/cogo/views/mentee/successed_cogo_detail_screen.dart
+++ b/lib/features/cogo/views/mentee/successed_cogo_detail_screen.dart
@@ -1,7 +1,7 @@
+import 'package:cogo/common/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:cogo/common/widgets/header.dart';
-import 'package:cogo/features/cogo/view_models/mentee/successed_cogo_detail_view_model.dart';
+import 'package:cogo/features/cogo/view_models/mentor/successed_cogo_detail_view_model.dart';
 
 class SuccessedCogoDetailScreen extends StatelessWidget {
   const SuccessedCogoDetailScreen({super.key});
@@ -10,153 +10,87 @@ class SuccessedCogoDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
       create: (_) => SuccessedCogoDetailViewModel(),
-      child: Scaffold(
-        backgroundColor: Colors.white,
-        body: SafeArea(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Expanded(
-                child: SingleChildScrollView(
-                  child: Padding(
-                    padding: const EdgeInsets.only(top: 5.0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.only(left: 15.0),
-                          child: Header(
-                            title: '김지은님이 코고신청을 보냈어요',
-                            subtitle: 'COGO를 하면서 많은 성장을 기원해요!',
-                            onBackButtonPressed: () => Navigator.of(context).pop(),
-                          ),
-                        ),
-                        const SizedBox(height: 20),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-                          child: ConstrainedBox(
-                            constraints: const BoxConstraints(
-                              minWidth: 0,
-                              maxWidth: double.infinity,
-                            ),
-                            child: IntrinsicWidth(
-                              child: Container(
-                                padding: const EdgeInsets.all(16.0),
-                                decoration: BoxDecoration(
-                                  color: const Color(0xFFF7F7F7),
-                                  borderRadius: BorderRadius.circular(20),
-                                ),
-                                child: const Text(
-                                  '안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구 안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구 안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구 안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구',
-                                  style: TextStyle(
-                                    fontFamily: 'PretendardMedium',
-                                    fontSize: 12,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 20),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              _buildDateBox(context, '8/3'),
-                            ],
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 10.0),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              Consumer<SuccessedCogoDetailViewModel>(
-                                builder: (context, viewModel, child) {
-                                  return _buildTimeSlotButton(
-                                    context,
-                                    '09:00 ~ 10:00',
-                                    0,
-                                    viewModel.selectedTimeSlotIndex,
-                                    viewModel.selectTimeSlot,
-                                  );
-                                },
-                              ),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ],
+      builder: (context, child) {
+        return Scaffold(
+          backgroundColor: Colors.white,
+          body: SafeArea(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(child: _buildContent(context)),
+              ],
+            ),
           ),
-        ),
+        );
+      },
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.only(top: 5.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildHeader(context),
+          const SizedBox(height: 20),
+          _buildMessageContainer(),
+          _buildDateAndTimePicker(),
+        ],
       ),
     );
   }
 
-  Widget _buildDateBox(BuildContext context, String date) {
-    return Expanded(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 5.0),
+  Widget _buildHeader(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 15.0),
+      child: Header(
+        title: '김지은님이 코고신청을 보냈어요',
+        subtitle: 'COGO를 하면서 많은 성장을 기원해요!',
+        onBackButtonPressed: () => Navigator.of(context).pop(),
+      ),
+    );
+  }
+
+  Widget _buildMessageContainer() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 15.0),
+      child: IntrinsicWidth(
         child: Container(
-          height: 50,
-          decoration: const BoxDecoration(
-            color: Colors.black,
-            shape: BoxShape.circle,
+          padding: const EdgeInsets.all(16.0),
+          decoration: BoxDecoration(
+            color: const Color(0xFFF7F7F7),
+            borderRadius: BorderRadius.circular(20),
           ),
-          alignment: Alignment.center,
-          child: Text(
-            date,
-            style: const TextStyle(
-              color: Colors.white,
-              fontFamily: 'PretendardMedium',
-              fontSize: 14,
-            ),
+          child: const Text(
+            '안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구 안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구 안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구 안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구',
+            style: CogoTextStyle.body12,
           ),
         ),
       ),
     );
   }
 
-  Widget _buildTimeSlotButton(BuildContext context, String text, int index, int selectedIndex, Function(int) onSelect) {
-    final bool isSelected = index == selectedIndex;
-
-    return Expanded(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 5.0),
-        child: SizedBox(
-          height: 30,
-          child: ElevatedButton(
-            onPressed: () {
-              onSelect(index);
-            },
-            style: ElevatedButton.styleFrom(
-              padding: const EdgeInsets.symmetric(vertical: 0),
-              backgroundColor: isSelected ? Colors.black : Colors.white,
-              foregroundColor: isSelected ? Colors.white : const Color(0xFF8F8F8F),
-              elevation: 0,
-              textStyle: const TextStyle(
-                fontFamily: 'PretendardMedium',
-                fontSize: 12,
-              ),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(20),
-                side: const BorderSide(color: Colors.grey),
-              ),
-            ),
-            child: Text(
-              text,
-              style: TextStyle(
-                color: isSelected ? Colors.white : const Color(0xFF8F8F8F),
-              ),
+  Widget _buildDateAndTimePicker() {
+    return Consumer<SuccessedCogoDetailViewModel>(
+      builder: (context, viewModel, child) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 15.0),
+          child: SizedBox(
+            height: 100,
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              children: [
+                DatePicker(date: DateTime.now(), day: DateTime.now()),
+                const SizedBox(width: 5),
+                TimePicker(
+                  timeSlots: ['09:00 ~ 10:00'],
+                ),
+              ],
             ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/features/cogo/views/mentee/successed_cogo_screen.dart
+++ b/lib/features/cogo/views/mentee/successed_cogo_screen.dart
@@ -1,3 +1,5 @@
+import 'package:cogo/common/widgets/atoms/texts/texts.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:go_router/go_router.dart';
@@ -38,7 +40,7 @@ class SuccessedCogoScreen extends StatelessWidget {
                           final item = viewModel.items[index];
                           return GestureDetector(
                             onTap: () {
-                              // 클릭 시 수행할 작업 추가
+                              //TODO 클릭 시 수행할 작업 추가
                               context.push('/successedCogoDetail');
                             },
                             child: Container(
@@ -49,23 +51,14 @@ class SuccessedCogoScreen extends StatelessWidget {
                                 borderRadius: BorderRadius.circular(20),
                               ),
                               child: Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
-                                  Text(
-                                    item['title']!,
-                                    style: const TextStyle(
-                                      fontFamily: 'PretendardMedium',
-                                      fontSize: 16,
-                                    ),
-                                  ),
-                                  Text(
-                                    item['date']!,
-                                    style: const TextStyle(
-                                      fontFamily: 'PretendardMedium',
-                                      fontSize: 12,
-                                      color: Colors.grey,
-                                    ),
-                                  ),
+                                  Text(item['title']!,
+                                      style: CogoTextStyle.body16),
+                                  Text(item['date']!,
+                                      style: CogoTextStyle.body12.copyWith(
+                                          color: CogoColor.systemGray03)),
                                 ],
                               ),
                             ),

--- a/lib/features/cogo/views/mentor/cogo_screen.dart
+++ b/lib/features/cogo/views/mentor/cogo_screen.dart
@@ -1,6 +1,8 @@
+import 'package:cogo/constants/colors.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cogo/features/cogo/view_models/mentor/cogo_view_model.dart';
+import 'package:cogo/common/widgets/widgets.dart';
 
 class CogoScreen extends StatelessWidget {
   const CogoScreen({super.key});
@@ -21,21 +23,15 @@ class CogoScreen extends StatelessWidget {
                   padding: EdgeInsets.only(left: 15.0),
                   child: Text(
                     '내 코고함',
-                    style: TextStyle(
-                      fontFamily: 'PretendardMedium',
-                      fontSize: 22,
-                    ),
+                    style: CogoTextStyle.body18,
                   ),
                 ),
-                const Padding(
-                  padding: EdgeInsets.symmetric(horizontal: 16.0),
+                Padding(
+                  padding: const EdgeInsets.symmetric(horizontal: 16.0),
                   child: Text(
                     'COGO를 하면서 많은 성장을 기원해요!',
-                    style: TextStyle(
-                      fontFamily: 'PretendardMedium',
-                      fontSize: 12,
-                      color: Color(0xFFAEAEB2),
-                    ),
+                    style: CogoTextStyle.body12
+                        .copyWith(color: CogoColor.systemGray03),
                   ),
                 ),
                 const SizedBox(height: 20),
@@ -46,10 +42,7 @@ class CogoScreen extends StatelessWidget {
                         ListTile(
                           title: const Text(
                             '받은 코고',
-                            style: TextStyle(
-                              fontFamily: 'PretendardMedium',
-                              fontSize: 18,
-                            ),
+                            style: CogoTextStyle.body16,
                           ),
                           trailing: const Icon(Icons.chevron_right),
                           onTap: () {
@@ -62,10 +55,7 @@ class CogoScreen extends StatelessWidget {
                         ListTile(
                           title: const Text(
                             '성사된 코고',
-                            style: TextStyle(
-                              fontFamily: 'PretendardMedium',
-                              fontSize: 18,
-                            ),
+                            style: CogoTextStyle.body16,
                           ),
                           trailing: const Icon(Icons.chevron_right),
                           onTap: () {

--- a/lib/features/cogo/views/mentor/received_cogo_detail_screen.dart
+++ b/lib/features/cogo/views/mentor/received_cogo_detail_screen.dart
@@ -1,7 +1,8 @@
+import 'package:cogo/common/widgets/atoms/texts/styles.dart';
+import 'package:cogo/common/widgets/widgets.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:cogo/common/widgets/header.dart';
-import 'package:cogo/common/widgets/custom_button.dart';
 import 'package:cogo/features/cogo/view_models/mentor/received_cogo_detail_view_model.dart';
 
 class ReceivedCogoDetailScreen extends StatelessWidget {
@@ -29,7 +30,8 @@ class ReceivedCogoDetailScreen extends StatelessWidget {
                           child: Header(
                             title: '김지은님이 코고신청을 보냈어요',
                             subtitle: 'COGO를 하면서 많은 성장을 기원해요!',
-                            onBackButtonPressed: () => Navigator.of(context).pop(),
+                            onBackButtonPressed: () =>
+                                Navigator.of(context).pop(),
                           ),
                         ),
                         const SizedBox(height: 20),
@@ -47,43 +49,45 @@ class ReceivedCogoDetailScreen extends StatelessWidget {
                                   color: const Color(0xFFF7F7F7),
                                   borderRadius: BorderRadius.circular(20),
                                 ),
-                                child: const Text(
+                                child: Text(
                                   '안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구',
-                                  style: TextStyle(
-                                    fontFamily: 'PretendardMedium',
-                                    fontSize: 12,
-                                  ),
+                                  style: CogoTextStyle.body12
+                                      .copyWith(color: CogoColor.systemGray05),
                                 ),
                               ),
                             ),
                           ),
                         ),
-                        const SizedBox(height: 20),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              _buildDateBox(context, '7/31'),
-                              _buildDateBox(context, '8/3'),
-                              _buildDateBox(context, '9/9'),
-                            ],
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 10.0),
-                          child: Consumer<ReceivedCogoDetailViewModel>(
-                            builder: (context, viewModel, child) {
-                              return Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                                children: [
-                                  _buildTimeSlotButton(context, '09:00 ~ 10:00', 0, viewModel),
-                                  _buildTimeSlotButton(context, '10:00 ~ 11:00', 1, viewModel),
-                                  _buildTimeSlotButton(context, '11:00 ~ 12:00', 2, viewModel),
-                                ],
-                              );
-                            },
-                          ),
+                        Consumer<ReceivedCogoDetailViewModel>(
+                          builder: (context, viewModel, child) {
+                            return Padding(
+                              padding: const EdgeInsets.symmetric(
+                                  horizontal: 15.0), // Adds horizontal margins
+                              child: SizedBox(
+                                height:
+                                    100, // Specify a height to make the ListView visible
+                                child: ListView(
+                                  scrollDirection: Axis.horizontal,
+                                  children: [
+                                    DatePicker(
+                                      date: DateTime.now(),
+                                      day: DateTime.now(),
+                                    ),
+                                    const SizedBox(width: 5),
+                                    TimePicker(
+                                      selectedTimeSlot:
+                                          viewModel.selectedTimeSlotIndex,
+                                      onTimeSlotSelected:
+                                          viewModel.selectTimeSlot,
+                                      timeSlots: [
+                                        '09:00 ~ 10:00',
+                                      ],
+                                    ),
+                                  ],
+                                ),
+                              ),
+                            );
+                          },
                         ),
                       ],
                     ),
@@ -95,23 +99,27 @@ class ReceivedCogoDetailScreen extends StatelessWidget {
                 child: Consumer<ReceivedCogoDetailViewModel>(
                   builder: (context, viewModel, child) {
                     return Row(
-                      mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                       children: [
-                        CustomButton(
-                          text: '거절',
-                          isSelected: false,
-                          onPressed: () {
-                            viewModel.reject(context);
-                          },
+                        Expanded(
+                          child: CustomButton(
+                            text: '거절',
+                            isSelected: false,
+                            onPressed: () {
+                              viewModel.reject(context);
+                            },
+                          ),
                         ),
-                        CustomButton(
-                          text: '수락',
-                          isSelected: viewModel.isAcceptSelected,
-                          onPressed: viewModel.isAcceptSelected
-                              ? () {
-                            viewModel.accept(context);
-                          }
-                              : () {}, // 여기서 빈 함수 전달
+                        const SizedBox(width: 10),
+                        Expanded(
+                          child: CustomButton(
+                            text: '수락',
+                            isSelected: viewModel.isAcceptSelected,
+                            onPressed: viewModel.isAcceptSelected
+                                ? () {
+                                    viewModel.accept(context);
+                                  }
+                                : () {}, // 빈 함수 전달
+                          ),
                         ),
                       ],
                     );
@@ -119,69 +127,6 @@ class ReceivedCogoDetailScreen extends StatelessWidget {
                 ),
               ),
             ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDateBox(BuildContext context, String date) {
-    return Expanded(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 5.0),
-        child: Container(
-          height: 50,
-          decoration: const BoxDecoration(
-            color: Colors.black,
-            shape: BoxShape.circle,
-          ),
-          alignment: Alignment.center,
-          child: Text(
-            date,
-            style: const TextStyle(
-              color: Colors.white,
-              fontFamily: 'PretendardMedium',
-              fontSize: 14,
-            ),
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildTimeSlotButton(
-      BuildContext context, String text, int index, ReceivedCogoDetailViewModel viewModel) {
-    final bool isSelected = index == viewModel.selectedTimeSlotIndex;
-
-    return Expanded(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 5.0),
-        child: SizedBox(
-          height: 30,
-          child: ElevatedButton(
-            onPressed: () {
-              viewModel.selectTimeSlot(index);
-            },
-            style: ElevatedButton.styleFrom(
-              padding: const EdgeInsets.symmetric(vertical: 0),
-              backgroundColor: isSelected ? Colors.black : Colors.white,
-              foregroundColor: isSelected ? Colors.white : const Color(0xFF8F8F8F),
-              elevation: 0,
-              textStyle: const TextStyle(
-                fontFamily: 'PretendardMedium',
-                fontSize: 12,
-              ),
-              shape: RoundedRectangleBorder(
-                borderRadius: BorderRadius.circular(20),
-                side: const BorderSide(color: Colors.grey),
-              ),
-            ),
-            child: Text(
-              text,
-              style: TextStyle(
-                color: isSelected ? Colors.white : const Color(0xFF8F8F8F),
-              ),
-            ),
           ),
         ),
       ),

--- a/lib/features/cogo/views/mentor/received_cogo_screen.dart
+++ b/lib/features/cogo/views/mentor/received_cogo_screen.dart
@@ -1,6 +1,7 @@
+import 'package:cogo/common/widgets/widgets.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:cogo/common/widgets/header.dart';
 import 'package:cogo/features/cogo/view_models/mentor/received_cogo_view_model.dart';
 
 class ReceivedCogoScreen extends StatelessWidget {
@@ -47,23 +48,13 @@ class ReceivedCogoScreen extends StatelessWidget {
                                 borderRadius: BorderRadius.circular(20),
                               ),
                               child: Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
-                                  Text(
-                                    item.title,
-                                    style: const TextStyle(
-                                      fontFamily: 'PretendardMedium',
-                                      fontSize: 16,
-                                    ),
-                                  ),
-                                  Text(
-                                    item.date,
-                                    style: const TextStyle(
-                                      fontFamily: 'PretendardMedium',
-                                      fontSize: 12,
-                                      color: Colors.grey,
-                                    ),
-                                  ),
+                                  Text(item.title, style: CogoTextStyle.body16),
+                                  Text(item.date,
+                                      style: CogoTextStyle.body12.copyWith(
+                                          color: CogoColor.systemGray03)),
                                 ],
                               ),
                             ),

--- a/lib/features/cogo/views/mentor/successed_cogo_detail_screen.dart
+++ b/lib/features/cogo/views/mentor/successed_cogo_detail_screen.dart
@@ -1,6 +1,6 @@
+import 'package:cogo/common/widgets/widgets.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
-import 'package:cogo/common/widgets/header.dart';
 import 'package:cogo/features/cogo/view_models/mentor/successed_cogo_detail_view_model.dart';
 
 class SuccessedCogoDetailScreen extends StatelessWidget {
@@ -10,146 +10,87 @@ class SuccessedCogoDetailScreen extends StatelessWidget {
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
       create: (_) => SuccessedCogoDetailViewModel(),
-      child: Scaffold(
-        backgroundColor: Colors.white,
-        body: SafeArea(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-            children: [
-              Expanded(
-                child: SingleChildScrollView(
-                  child: Padding(
-                    padding: const EdgeInsets.only(top: 5.0),
-                    child: Column(
-                      crossAxisAlignment: CrossAxisAlignment.start,
-                      children: [
-                        Padding(
-                          padding: const EdgeInsets.only(left: 15.0),
-                          child: Header(
-                            title: '김지은님이 코고신청을 보냈어요',
-                            subtitle: 'COGO를 하면서 많은 성장을 기원해요!',
-                            onBackButtonPressed: () => Navigator.of(context).pop(),
-                          ),
-                        ),
-                        const SizedBox(height: 20),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-                          child: ConstrainedBox(
-                            constraints: BoxConstraints(
-                              minWidth: 0,
-                              maxWidth: double.infinity,
-                            ),
-                            child: IntrinsicWidth(
-                              child: Container(
-                                padding: const EdgeInsets.all(16.0),
-                                decoration: BoxDecoration(
-                                  color: const Color(0xFFF7F7F7),
-                                  borderRadius: BorderRadius.circular(20),
-                                ),
-                                child: const Text(
-                                  '안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구...',
-                                  style: TextStyle(
-                                    fontFamily: 'PretendardMedium',
-                                    fontSize: 12,
-                                  ),
-                                ),
-                              ),
-                            ),
-                          ),
-                        ),
-                        const SizedBox(height: 20),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 15.0),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              _buildDateBox(context, '8/3'),
-                            ],
-                          ),
-                        ),
-                        Padding(
-                          padding: const EdgeInsets.symmetric(horizontal: 15.0, vertical: 10.0),
-                          child: Row(
-                            mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                            children: [
-                              _buildTimeSlotButton(context, '09:00 ~ 10:00', 0),
-                            ],
-                          ),
-                        ),
-                      ],
-                    ),
-                  ),
-                ),
-              ),
-            ],
-          ),
-        ),
-      ),
-    );
-  }
-
-  Widget _buildDateBox(BuildContext context, String date) {
-    return Expanded(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 5.0),
-        child: Container(
-          height: 50,
-          decoration: const BoxDecoration(
-            color: Colors.black,
-            shape: BoxShape.circle,
-          ),
-          alignment: Alignment.center,
-          child: Text(
-            date,
-            style: const TextStyle(
-              color: Colors.white,
-              fontFamily: 'PretendardMedium',
-              fontSize: 14,
+      builder: (context, child) {
+        return Scaffold(
+          backgroundColor: Colors.white,
+          body: SafeArea(
+            child: Column(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                Expanded(child: _buildContent(context)),
+              ],
             ),
           ),
+        );
+      },
+    );
+  }
+
+  Widget _buildContent(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.only(top: 5.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildHeader(context),
+          const SizedBox(height: 20),
+          _buildMessageContainer(),
+          _buildDateAndTimePicker(),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildHeader(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.only(left: 15.0),
+      child: Header(
+        title: '김지은님이 코고신청을 보냈어요',
+        subtitle: 'COGO를 하면서 많은 성장을 기원해요!',
+        onBackButtonPressed: () => Navigator.of(context).pop(),
+      ),
+    );
+  }
+
+  Widget _buildMessageContainer() {
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 15.0),
+      child: IntrinsicWidth(
+        child: Container(
+          padding: const EdgeInsets.all(16.0),
+          decoration: BoxDecoration(
+            color: const Color(0xFFF7F7F7),
+            borderRadius: BorderRadius.circular(20),
+          ),
+          child: const Text(
+            '안녕하세요, 저는 코고 개발자 김지은입니다. 다름이 아니라, 어쩌구저쩌구...',
+            style: CogoTextStyle.body12,
+          ),
         ),
       ),
     );
   }
 
-  Widget _buildTimeSlotButton(BuildContext context, String text, int index) {
-    return Expanded(
-      child: Padding(
-        padding: const EdgeInsets.symmetric(horizontal: 5.0),
-        child: SizedBox(
-          height: 30,
-          child: Consumer<SuccessedCogoDetailViewModel>(
-            builder: (context, viewModel, child) {
-              final isSelected = viewModel.isTimeSlotSelected(index);
-              return ElevatedButton(
-                onPressed: () {
-                  viewModel.selectTimeSlot(index);
-                },
-                style: ElevatedButton.styleFrom(
-                  padding: const EdgeInsets.symmetric(vertical: 0),
-                  backgroundColor: isSelected ? Colors.black : Colors.white,
-                  foregroundColor: isSelected ? Colors.white : const Color(0xFF8F8F8F),
-                  elevation: 0,
-                  textStyle: const TextStyle(
-                    fontFamily: 'PretendardMedium',
-                    fontSize: 12,
-                  ),
-                  shape: RoundedRectangleBorder(
-                    borderRadius: BorderRadius.circular(20),
-                    side: const BorderSide(color: Colors.grey),
-                  ),
+  Widget _buildDateAndTimePicker() {
+    return Consumer<SuccessedCogoDetailViewModel>(
+      builder: (context, viewModel, child) {
+        return Padding(
+          padding: const EdgeInsets.symmetric(horizontal: 15.0),
+          child: SizedBox(
+            height: 100,
+            child: ListView(
+              scrollDirection: Axis.horizontal,
+              children: [
+                DatePicker(date: DateTime.now(), day: DateTime.now()),
+                const SizedBox(width: 5),
+                TimePicker(
+                  timeSlots: ['09:00 ~ 10:00'],
                 ),
-                child: Text(
-                  text,
-                  style: TextStyle(
-                    color: isSelected ? Colors.white : const Color(0xFF8F8F8F),
-                  ),
-                ),
-              );
-            },
+              ],
+            ),
           ),
-        ),
-      ),
+        );
+      },
     );
   }
 }

--- a/lib/features/cogo/views/mentor/successed_cogo_screen.dart
+++ b/lib/features/cogo/views/mentor/successed_cogo_screen.dart
@@ -1,3 +1,5 @@
+import 'package:cogo/common/widgets/atoms/texts/styles.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cogo/common/widgets/header.dart';
@@ -47,22 +49,15 @@ class SuccessedCogoScreen extends StatelessWidget {
                                 borderRadius: BorderRadius.circular(20),
                               ),
                               child: Row(
-                                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                                mainAxisAlignment:
+                                    MainAxisAlignment.spaceBetween,
                                 children: [
-                                  Text(
-                                    item['title']!,
-                                    style: const TextStyle(
-                                      fontFamily: 'PretendardMedium',
-                                      fontSize: 16,
-                                    ),
-                                  ),
+                                  Text(item['title']!,
+                                      style: CogoTextStyle.body16),
                                   Text(
                                     item['date']!,
-                                    style: const TextStyle(
-                                      fontFamily: 'PretendardMedium',
-                                      fontSize: 12,
-                                      color: Colors.grey,
-                                    ),
+                                    style: CogoTextStyle.body12.copyWith(
+                                        color: CogoColor.systemGray03),
                                   ),
                                 ],
                               ),

--- a/lib/features/home/apply/view_models/memo_view_model.dart
+++ b/lib/features/home/apply/view_models/memo_view_model.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:cogo/constants/paths.dart';
 import 'package:go_router/go_router.dart';
-import 'package:cogo/constants/paths.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
 class MemoViewModel extends ChangeNotifier {

--- a/lib/features/home/apply/view_models/schedule_view_model.dart
+++ b/lib/features/home/apply/view_models/schedule_view_model.dart
@@ -7,6 +7,20 @@ class ScheduleViewModel extends ChangeNotifier {
   DateTime selectedDate = DateTime.now();
   int selectedTimeSlot = -1;
 
+  final List<String> timeSlots = [
+    '09:00 ~ 10:00',
+    '10:00 ~ 11:00',
+    '11:00 ~ 12:00',
+    '13:00 ~ 14:00',
+    '14:00 ~ 15:00',
+    '15:00 ~ 16:00',
+    '16:00 ~ 17:00',
+    '17:00 ~ 18:00',
+    '18:00 ~ 19:00',
+    '19:00 ~ 20:00',
+    '20:00 ~ 21:00',
+  ];
+
   void onDateSelected(DateTime date) {
     selectedDate = date;
     notifyListeners();

--- a/lib/features/home/apply/views/matching_screen.dart
+++ b/lib/features/home/apply/views/matching_screen.dart
@@ -1,3 +1,4 @@
+import 'package:cogo/common/widgets/atoms/texts/styles.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cogo/common/widgets/header.dart';
@@ -43,14 +44,12 @@ class MatchingScreen extends StatelessWidget {
                         width: double.infinity,
                         height: 50,
                         child: ElevatedButton(
-                          onPressed: () => viewModel.completeApplication(context),
+                          onPressed: () =>
+                              viewModel.completeApplication(context),
                           style: ElevatedButton.styleFrom(
                             backgroundColor: Colors.black,
                             foregroundColor: Colors.white,
-                            textStyle: const TextStyle(
-                              fontFamily: 'PretendardMedium',
-                              fontSize: 18,
-                            ),
+                            textStyle: CogoTextStyle.body18,
                             shape: RoundedRectangleBorder(
                               borderRadius: BorderRadius.circular(20),
                             ),

--- a/lib/features/home/apply/views/matching_screen.dart
+++ b/lib/features/home/apply/views/matching_screen.dart
@@ -1,8 +1,8 @@
-import 'package:cogo/common/widgets/atoms/texts/styles.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cogo/common/widgets/header.dart';
 import 'package:cogo/features/home/apply/view_models/matching_view_model.dart';
+import 'package:cogo/common/widgets/custom_button.dart';
 
 class MatchingScreen extends StatelessWidget {
   const MatchingScreen({super.key});
@@ -40,22 +40,11 @@ class MatchingScreen extends StatelessWidget {
                   padding: const EdgeInsets.all(16.0),
                   child: Consumer<MatchingViewModel>(
                     builder: (context, viewModel, child) {
-                      return SizedBox(
+                      return CustomButton(
+                        text: '코고 신청 완료하기',
+                        isSelected: true,
+                        onPressed: () => viewModel.completeApplication(context),
                         width: double.infinity,
-                        height: 50,
-                        child: ElevatedButton(
-                          onPressed: () =>
-                              viewModel.completeApplication(context),
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: Colors.black,
-                            foregroundColor: Colors.white,
-                            textStyle: CogoTextStyle.body18,
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(20),
-                            ),
-                          ),
-                          child: const Text('코고 신청 완료하기'),
-                        ),
                       );
                     },
                   ),

--- a/lib/features/home/apply/views/memo_screen.dart
+++ b/lib/features/home/apply/views/memo_screen.dart
@@ -1,7 +1,10 @@
+import 'package:cogo/common/widgets/atoms/texts/styles.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cogo/common/widgets/header.dart';
 import 'package:cogo/features/home/apply/view_models/memo_view_model.dart';
+import 'package:cogo/common/widgets/custom_button.dart';
 
 class MemoScreen extends StatelessWidget {
   const MemoScreen({super.key});
@@ -12,92 +15,66 @@ class MemoScreen extends StatelessWidget {
       create: (_) => MemoViewModel(),
       child: Scaffold(
         backgroundColor: Colors.white,
-        resizeToAvoidBottomInset: true,
+        resizeToAvoidBottomInset: false,
         body: SafeArea(
-          child: SingleChildScrollView(
-            padding: const EdgeInsets.only(top: 5.0),
-            child: Column(
-              mainAxisSize: MainAxisSize.min,
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(left: 15.0),
-                  child: Header(
-                    title: '멘토님께 드릴 메모를 적어보세요',
-                    subtitle: 'COGO를 하면서 많은 성장을 기원해요!',
-                    onBackButtonPressed: () => Navigator.of(context).pop(),
-                  ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Padding(
+                padding: const EdgeInsets.only(left: 15.0),
+                child: Header(
+                  title: '멘토님께 드릴 메모를 적어보세요',
+                  subtitle: 'COGO를 하면서 많은 성장을 기원해요!',
+                  onBackButtonPressed: () => Navigator.of(context).pop(),
                 ),
-                const SizedBox(height: 20),
-                Padding(
-                  padding: const EdgeInsets.symmetric(horizontal: 15.0),
-                  child: Consumer<MemoViewModel>(
-                    builder: (context, viewModel, child) {
-                      return Container(
-                        padding: const EdgeInsets.all(16.0),
-                        decoration: BoxDecoration(
-                          color: const Color(0xFFF7F7F7),
-                          borderRadius: BorderRadius.circular(20),
+              ),
+              const SizedBox(height: 20),
+              Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 15.0),
+                child: Consumer<MemoViewModel>(
+                  builder: (context, viewModel, child) {
+                    return Container(
+                      padding: const EdgeInsets.all(16.0),
+                      decoration: BoxDecoration(
+                        color: const Color(0xFFF7F7F7),
+                        borderRadius: BorderRadius.circular(20),
+                      ),
+                      child: TextField(
+                        controller: viewModel.controller,
+                        maxLength: 200,
+                        maxLines: 8,
+                        style: CogoTextStyle.body12,
+                        decoration: InputDecoration(
+                          hintText: '내용을 입력해주세요',
+                          hintStyle: CogoTextStyle.body12
+                              .copyWith(color: CogoColor.systemGray03),
+                          border: InputBorder.none,
+                          counterText: '${viewModel.charCount}/200',
+                          counterStyle: CogoTextStyle.body12
+                              .copyWith(color: CogoColor.systemGray03),
                         ),
-                        child: TextField(
-                          controller: viewModel.controller,
-                          maxLength: 200,
-                          maxLines: 8,
-                          decoration: InputDecoration(
-                            hintText: '내용을 입력해주세요',
-                            hintStyle: const TextStyle(
-                              fontFamily: 'PretendardMedium',
-                              fontSize: 14,
-                              color: Color(0xFFB4B4B4),
-                            ),
-                            border: InputBorder.none,
-                            counterText: '${viewModel.charCount}/200',
-                            counterStyle: const TextStyle(
-                              fontFamily: 'PretendardMedium',
-                              fontSize: 12,
-                              color: Color(0xFFB4B4B4),
-                            ),
-                          ),
-                        ),
-                      );
-                    },
-                  ),
+                      ),
+                    );
+                  },
                 ),
-                const SizedBox(height: 20),
-                Padding(
-                  padding: const EdgeInsets.all(16.0),
-                  child: SizedBox(
-                    width: double.infinity,
-                    height: 50,
-                    child: Consumer<MemoViewModel>(
-                      builder: (context, viewModel, child) {
-                        return ElevatedButton(
-                          onPressed: viewModel.charCount > 0
-                              ? () => viewModel.saveMemo(context)
-                              : null,
-                          style: ElevatedButton.styleFrom(
-                            backgroundColor: viewModel.charCount > 0
-                                ? Colors.black
-                                : Colors.grey[300],
-                            foregroundColor: viewModel.charCount > 0
-                                ? Colors.white
-                                : Colors.black,
-                            textStyle: const TextStyle(
-                              fontFamily: 'PretendardMedium',
-                              fontSize: 18,
-                            ),
-                            shape: RoundedRectangleBorder(
-                              borderRadius: BorderRadius.circular(20),
-                            ),
-                          ),
-                          child: const Text('다음'),
-                        );
-                      },
-                    ),
-                  ),
+              ),
+              const Spacer(),
+              Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Consumer<MemoViewModel>(
+                  builder: (context, viewModel, child) {
+                    return CustomButton(
+                      text: '다음',
+                      isSelected: viewModel.charCount > 0,
+                      onPressed: viewModel.charCount > 0
+                          ? () => viewModel.saveMemo(context)
+                          : null,
+                      width: double.infinity,
+                    );
+                  },
                 ),
-              ],
-            ),
+              ),
+            ],
           ),
         ),
       ),

--- a/lib/features/home/apply/views/memo_screen.dart
+++ b/lib/features/home/apply/views/memo_screen.dart
@@ -12,11 +12,12 @@ class MemoScreen extends StatelessWidget {
       create: (_) => MemoViewModel(),
       child: Scaffold(
         backgroundColor: Colors.white,
-        resizeToAvoidBottomInset: true,  // 키도브 오버 플로우 해결
+        resizeToAvoidBottomInset: true,
         body: SafeArea(
-          child: Padding(
+          child: SingleChildScrollView(
             padding: const EdgeInsets.only(top: 5.0),
             child: Column(
+              mainAxisSize: MainAxisSize.min,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
                 Padding(
@@ -62,38 +63,36 @@ class MemoScreen extends StatelessWidget {
                     },
                   ),
                 ),
-                const Spacer(),
+                const SizedBox(height: 20),
                 Padding(
                   padding: const EdgeInsets.all(16.0),
-                  child: Center(
-                    child: SizedBox(
-                      width: double.infinity,
-                      height: 50,
-                      child: Consumer<MemoViewModel>(
-                        builder: (context, viewModel, child) {
-                          return ElevatedButton(
-                            onPressed: viewModel.charCount > 0
-                                ? () => viewModel.saveMemo(context)
-                                : null,
-                            style: ElevatedButton.styleFrom(
-                              backgroundColor: viewModel.charCount > 0
-                                  ? Colors.black
-                                  : Colors.grey[300],
-                              foregroundColor: viewModel.charCount > 0
-                                  ? Colors.white
-                                  : Colors.black,
-                              textStyle: const TextStyle(
-                                fontFamily: 'PretendardMedium',
-                                fontSize: 18,
-                              ),
-                              shape: RoundedRectangleBorder(
-                                borderRadius: BorderRadius.circular(20),
-                              ),
+                  child: SizedBox(
+                    width: double.infinity,
+                    height: 50,
+                    child: Consumer<MemoViewModel>(
+                      builder: (context, viewModel, child) {
+                        return ElevatedButton(
+                          onPressed: viewModel.charCount > 0
+                              ? () => viewModel.saveMemo(context)
+                              : null,
+                          style: ElevatedButton.styleFrom(
+                            backgroundColor: viewModel.charCount > 0
+                                ? Colors.black
+                                : Colors.grey[300],
+                            foregroundColor: viewModel.charCount > 0
+                                ? Colors.white
+                                : Colors.black,
+                            textStyle: const TextStyle(
+                              fontFamily: 'PretendardMedium',
+                              fontSize: 18,
                             ),
-                            child: const Text('다음'),
-                          );
-                        },
-                      ),
+                            shape: RoundedRectangleBorder(
+                              borderRadius: BorderRadius.circular(20),
+                            ),
+                          ),
+                          child: const Text('다음'),
+                        );
+                      },
                     ),
                   ),
                 ),

--- a/lib/features/home/apply/views/schedule_screen.dart
+++ b/lib/features/home/apply/views/schedule_screen.dart
@@ -35,7 +35,8 @@ class ScheduleScreen extends StatelessWidget {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            DatePicker(
+                            HorizontalDatePicker(
+                              itemCount: 7,
                               selectedDate: viewModel.selectedDate,
                               onDateSelected: viewModel.onDateSelected,
                             ),
@@ -47,8 +48,7 @@ class ScheduleScreen extends StatelessWidget {
                                 selectedTimeSlot: viewModel.selectedTimeSlot,
                                 onTimeSlotSelected:
                                     viewModel.onTimeSlotSelected,
-                                timeSlots:
-                                    viewModel.timeSlots, // 뷰모델에서 timeSlots 전달
+                                timeSlots: viewModel.timeSlots,
                               ),
                             ),
                             const SizedBox(height: 20),

--- a/lib/features/home/apply/views/schedule_screen.dart
+++ b/lib/features/home/apply/views/schedule_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cogo/features/home/apply/view_models/schedule_view_model.dart';
 import 'package:cogo/common/widgets/widgets.dart';
+import 'package:cogo/constants/constants.dart';
 
 class ScheduleScreen extends StatelessWidget {
   const ScheduleScreen({super.key});
@@ -38,12 +39,14 @@ class ScheduleScreen extends StatelessWidget {
                               selectedDate: viewModel.selectedDate,
                               onDateSelected: viewModel.onDateSelected,
                             ),
-                            const Divider(color: Color(0xFFE2E2E2), thickness: 1),
+                            const Divider(
+                                color: CogoColor.systemGray01, thickness: 1),
                             Padding(
                               padding: const EdgeInsets.all(10.0),
                               child: TimePicker(
                                 selectedTimeSlot: viewModel.selectedTimeSlot,
-                                onTimeSlotSelected: viewModel.onTimeSlotSelected,
+                                onTimeSlotSelected:
+                                    viewModel.onTimeSlotSelected,
                               ),
                             ),
                             const SizedBox(height: 20),
@@ -62,10 +65,12 @@ class ScheduleScreen extends StatelessWidget {
                         height: 50, // 버튼 높이 유지
                         child: CustomButton(
                           text: '다음',
-                          isSelected: viewModel.selectedTimeSlot != -1,  // 선택된 경우 true
+                          isSelected:
+                              viewModel.selectedTimeSlot != -1, // 선택된 경우 true
                           onPressed: viewModel.selectedTimeSlot != -1
-                              ? () => viewModel.saveSelection(context)  // 선택된 경우 동작
-                              : null,  // 선택되지 않으면 비활성화
+                              ? () =>
+                                  viewModel.saveSelection(context) // 선택된 경우 동작
+                              : null, // 선택되지 않으면 비활성화
                         ),
                       );
                     },

--- a/lib/features/home/apply/views/schedule_screen.dart
+++ b/lib/features/home/apply/views/schedule_screen.dart
@@ -47,6 +47,8 @@ class ScheduleScreen extends StatelessWidget {
                                 selectedTimeSlot: viewModel.selectedTimeSlot,
                                 onTimeSlotSelected:
                                     viewModel.onTimeSlotSelected,
+                                timeSlots:
+                                    viewModel.timeSlots, // 뷰모델에서 timeSlots 전달
                               ),
                             ),
                             const SizedBox(height: 20),

--- a/lib/features/home/apply/views/schedule_screen.dart
+++ b/lib/features/home/apply/views/schedule_screen.dart
@@ -61,16 +61,13 @@ class ScheduleScreen extends StatelessWidget {
                   child: Consumer<ScheduleViewModel>(
                     builder: (context, viewModel, child) {
                       return SizedBox(
-                        width: double.infinity, // 버튼 너비를 화면 전체로 설정
-                        height: 50, // 버튼 높이 유지
+                        width: double.infinity,
                         child: CustomButton(
                           text: '다음',
-                          isSelected:
-                              viewModel.selectedTimeSlot != -1, // 선택된 경우 true
+                          isSelected: viewModel.selectedTimeSlot != -1,
                           onPressed: viewModel.selectedTimeSlot != -1
-                              ? () =>
-                                  viewModel.saveSelection(context) // 선택된 경우 동작
-                              : null, // 선택되지 않으면 비활성화
+                              ? () => viewModel.saveSelection(context)
+                              : null,
                         ),
                       );
                     },

--- a/lib/features/home/home/view/home_screen.dart
+++ b/lib/features/home/home/view/home_screen.dart
@@ -87,22 +87,20 @@ class _HomeScreenState extends State<HomeScreen> {
       builder: (context, viewModel, child) {
         final profiles = viewModel.profiles;
 
-        if (profiles == null ||
-            profiles.isEmpty ||
-            profiles.any((profile) => profile == null)) {
+        if (profiles == null || profiles.isEmpty) {
           return const Center(child: Text('멘토 정보가 없습니다'));
         }
 
         return ListView.builder(
           physics: const NeverScrollableScrollPhysics(),
           shrinkWrap: true,
-          scrollDirection: Axis.vertical, // 리스트 크기 고정
+          scrollDirection: Axis.vertical,
           itemCount: profiles.length,
           itemBuilder: (context, index) {
             final profileCard = profiles[index];
             return Padding(
-              padding: const EdgeInsets.symmetric(
-                  vertical: 8.0, horizontal: 16.0), // 세로와 양쪽 마진 추가
+              padding:
+                  const EdgeInsets.symmetric(vertical: 8.0, horizontal: 16.0),
               child: ProfileCard(
                 picture: profileCard.picture,
                 mentorName: profileCard.mentorName,

--- a/lib/features/home/profile/view/profile_detail_screen.dart
+++ b/lib/features/home/profile/view/profile_detail_screen.dart
@@ -8,16 +8,17 @@ import 'package:cogo/features/home/profile/view_model/profile_detail_view_model.
 class ProfileDetailScreen extends StatelessWidget {
   final String mentorId;
 
-  const ProfileDetailScreen({Key? key, required this.mentorId}) : super(key: key);
-
+  const ProfileDetailScreen({Key? key, required this.mentorId})
+      : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (context) => ProfileDetailViewModel(mentorId), // Pass mentorId to ViewModel
+      create: (context) =>
+          ProfileDetailViewModel(mentorId), // Pass mentorId to ViewModel
       child: Scaffold(
         backgroundColor: CogoColor.white50,
-        resizeToAvoidBottomInset: true, // 키보드 오버 플로우 해결
+        resizeToAvoidBottomInset: true,
         appBar: AppBar(
           backgroundColor: CogoColor.white50,
           elevation: 0,
@@ -67,9 +68,12 @@ class ProfileDetailScreen extends StatelessWidget {
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
                       ClipRRect(
-                        borderRadius: const BorderRadius.all(Radius.circular(20)),
+                        borderRadius:
+                            const BorderRadius.all(Radius.circular(20)),
                         child: Image.asset(
-                          profile.imageUrl.isNotEmpty ? profile.imageUrl : 'assets/default_img.png',
+                          profile.imageUrl.isNotEmpty
+                              ? profile.imageUrl
+                              : 'assets/default_img.png',
                           width: double.infinity,
                           height: 150,
                           fit: BoxFit.cover,
@@ -105,10 +109,7 @@ class ProfileDetailScreen extends StatelessWidget {
                         style: ElevatedButton.styleFrom(
                           backgroundColor: CogoColor.main,
                           foregroundColor: CogoColor.white50,
-                          textStyle: const TextStyle(
-                            fontFamily: 'PretendardMedium',
-                            fontSize: 18,
-                          ),
+                          textStyle: CogoTextStyle.body18,
                           shape: RoundedRectangleBorder(
                             borderRadius: BorderRadius.circular(20),
                           ),

--- a/lib/route/routes.dart
+++ b/lib/route/routes.dart
@@ -222,8 +222,7 @@ final AppRouter = GoRouter(
     GoRoute(
       path: Paths.profileDetail,
       builder: (context, state) {
-        final mentorId =
-            state.uri.queryParameters['mentorId']; // Query parameter 사용
+        final mentorId = state.uri.queryParameters['mentorId'];
         return ProfileDetailScreen(mentorId: mentorId!);
       },
     ),


### PR DESCRIPTION
## Issue

- Resolves #47 

## Description
기존 디자인 UI에서 현재 변경된 디자인 UI로 변경 작업 진행하였습니다.

### 디자인 시스템 적용
하드코딩 되었던 디자인 코드 부분을 디자인 시스템 적용으로 수정하였습니다.

### home, cogo 디자인 수정
완성된 와이어 프레임 디자인에 맞게 수정하였습니다.

### date picker, time picker 위젯 수정
**date picker**
기존 date picker코드에서 두개로 나누는 작업을 진행했습니다.
- date picker
- horizontal date picker

date picker은 디자인 시스템에 있는 date picker하나를 나타냅니다. 날짜와 요일을 집어넣어서 호출하면 아래와 같은 date 위젯을 만듭니다.

<img width="137" alt="image" src="https://github.com/user-attachments/assets/ef73da21-ad37-4dfe-abe3-6d6372d7364b">

**horizontal date picker**
'멘티입장 코고 신청 - 시간선택' 페이지에서의 날짜 선택을 위해 따로 만들어놓은 위젯입니다.

**time picker**
기존 time picker 위젯의 책임이었던 time slot을 호출하는 UI의 책임으로 바꿨습니다.
전체적인 위치와 time picker의 크기, 색상 또한 변경하였습니다.
time picker에 넣고 싶은 String 타입의 time slot을 넣으면 아래와 같은 위젯을 만들어줍니다.

<img width="510" alt="image" src="https://github.com/user-attachments/assets/b837ab0f-66ec-49f3-b238-7f63fece6c63">


## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)

## Screenshot

https://github.com/user-attachments/assets/26a6bd47-6b73-4eb6-99e8-86e577b1b647


