### PR TITLE
[Feature] 멘토 자기소개 입력 api 연동

### DIFF
--- a/lib/constants/apis.dart
+++ b/lib/constants/apis.dart
@@ -30,4 +30,5 @@ abstract class Apis {
   // 멘토 관련 api
   static const String mentor = "mentors";
   static const String mentorPart = "mentors/part";
+  static const String mentorIntroduction = "mentors/introductions";
 }

--- a/lib/data/dto/response/mentor_introduction_response.dart
+++ b/lib/data/dto/response/mentor_introduction_response.dart
@@ -1,8 +1,8 @@
 class MentorIntroductionResponse {
-  final String? introductionTitle;
-  final String? introductionDescription;
-  final String? introductionAnswer1;
-  final String? introductionAnswer2;
+  final String introductionTitle;
+  final String introductionDescription;
+  final String introductionAnswer1;
+  final String introductionAnswer2;
 
   MentorIntroductionResponse({
     required this.introductionTitle,
@@ -13,19 +13,19 @@ class MentorIntroductionResponse {
 
   factory MentorIntroductionResponse.fromJson(Map<String, dynamic> json) {
     return MentorIntroductionResponse(
-      introductionTitle: json['introductionTitle'],
-      introductionDescription: json['introductionDescription'],
-      introductionAnswer1: json['introductionAnswer1'],
-      introductionAnswer2: json['introductionAnswer2'],
+      introductionTitle: json['introduction_title'],
+      introductionDescription: json['introduction_description'],
+      introductionAnswer1: json['introduction_answer1'],
+      introductionAnswer2: json['introduction_answer2'],
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
-      'introductionTitle': introductionTitle,
-      'introductionDescription': introductionDescription,
-      'introductionAnswer1': introductionAnswer1,
-      'introductionAnswer2': introductionAnswer2,
+      'introduction_title': introductionTitle,
+      'introduction_description': introductionDescription,
+      'introduction_answer1': introductionAnswer1,
+      'introduction_answer2': introductionAnswer2,
     };
   }
 }

--- a/lib/data/dto/response/mentor_introduction_response.dart
+++ b/lib/data/dto/response/mentor_introduction_response.dart
@@ -1,0 +1,31 @@
+class MentorIntroductionResponse {
+  final String? introductionTitle;
+  final String? introductionDescription;
+  final String? introductionAnswer1;
+  final String? introductionAnswer2;
+
+  MentorIntroductionResponse({
+    required this.introductionTitle,
+    required this.introductionDescription,
+    required this.introductionAnswer1,
+    required this.introductionAnswer2,
+  });
+
+  factory MentorIntroductionResponse.fromJson(Map<String, dynamic> json) {
+    return MentorIntroductionResponse(
+      introductionTitle: json['introductionTitle'],
+      introductionDescription: json['introductionDescription'],
+      introductionAnswer1: json['introductionAnswer1'],
+      introductionAnswer2: json['introductionAnswer2'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'introductionTitle': introductionTitle,
+      'introductionDescription': introductionDescription,
+      'introductionAnswer1': introductionAnswer1,
+      'introductionAnswer2': introductionAnswer2,
+    };
+  }
+}

--- a/lib/data/service/mentor_service.dart
+++ b/lib/data/service/mentor_service.dart
@@ -86,7 +86,7 @@ class MentorService {
     }
   }
 
-  // 멘토 자기소개 입력
+  //멘토 자기소개 입력
   Future<MentorIntroductionResponse> patchMentorIntroduction(
       String introductionTitle,
       String introductionDescription,
@@ -109,14 +109,18 @@ class MentorService {
       );
 
       if (response.statusCode == 200) {
-        log(response.data);
-        final baseResponse = BaseResponse<MentorIntroductionResponse>.fromJson(
-          response.data,
-          (contentJson) {
-            return MentorIntroductionResponse.fromJson(contentJson);
-          },
-        );
-        return baseResponse.content;
+        log(response.data.toString());
+
+        final responseData = response.data;
+
+        // 데이터가 Map 형식인지 확인하여 서버 응답 처리추가
+        if (responseData is Map<String, dynamic> &&
+            responseData['content'] != null) {
+          final contentJson = responseData['content'] as Map<String, dynamic>;
+          return MentorIntroductionResponse.fromJson(contentJson);
+        } else {
+          throw Exception('Unexpected response format: $responseData');
+        }
       } else {
         throw Exception(
             'Failed to patch mentor introduction: ${response.data}');

--- a/lib/data/service/mentor_service.dart
+++ b/lib/data/service/mentor_service.dart
@@ -1,11 +1,13 @@
+import 'dart:developer';
+
 import 'package:cogo/constants/apis.dart';
 import 'package:cogo/data/di/api_client.dart';
 import 'package:cogo/data/dto/response/base_response.dart';
 import 'package:cogo/data/dto/response/mentor_detail_response.dart';
+import 'package:cogo/data/dto/response/mentor_introduction_response.dart';
 import 'package:cogo/data/dto/response/mentor_part_response.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_config/flutter_config.dart';
-
 
 class MentorService {
   final ApiClient _apiClient = ApiClient();
@@ -29,7 +31,7 @@ class MentorService {
         print(response.data); // 서버 응답을 출력하여 확인
         final baseResponse = BaseResponse<MentorDetailResponse>.fromJson(
           response.data,
-              (contentJson) {
+          (contentJson) {
             return MentorDetailResponse.fromJson(contentJson);
           },
         );
@@ -43,6 +45,7 @@ class MentorService {
       throw Exception('An unexpected error occurred: $e');
     }
   }
+
   // 파트별 멘토리스트 호출
   Future<List<MentorPartResponse>> getMentorPart(String part) async {
     try {
@@ -78,6 +81,48 @@ class MentorService {
       }
     } on DioException catch (e) {
       return <MentorPartResponse>[];
+    } catch (e) {
+      throw Exception('An unexpected error occurred: $e');
+    }
+  }
+
+  // 멘토 자기소개 입력
+  Future<MentorIntroductionResponse> patchMentorIntroduction(
+      String introductionTitle,
+      String introductionDescription,
+      String introductionAnswer1,
+      String introductionAnswer2) async {
+    try {
+      final response = await _apiClient.dio.patch(
+        apiVersion + Apis.mentorIntroduction,
+        data: {
+          'introduction_title': introductionTitle,
+          'introduction_description': introductionDescription,
+          'introduction_answer1': introductionAnswer1,
+          'introduction_answer2': introductionAnswer2,
+        },
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $token',
+          },
+        ),
+      );
+
+      if (response.statusCode == 200) {
+        log(response.data);
+        final baseResponse = BaseResponse<MentorIntroductionResponse>.fromJson(
+          response.data,
+          (contentJson) {
+            return MentorIntroductionResponse.fromJson(contentJson);
+          },
+        );
+        return baseResponse.content;
+      } else {
+        throw Exception(
+            'Failed to patch mentor introduction: ${response.data}');
+      }
+    } on DioException catch (e) {
+      throw Exception('Error: ${e.response?.data ?? e.message}');
     } catch (e) {
       throw Exception('An unexpected error occurred: $e');
     }

--- a/lib/features/home/mentor_detail/view_models/mentor_introduction_view_model.dart
+++ b/lib/features/home/mentor_detail/view_models/mentor_introduction_view_model.dart
@@ -53,12 +53,14 @@ class MentorIntroductionViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
+  // SharedPreferences에 저장
   Future<void> _saveToPreferences() async {
     final prefs = await SharedPreferences.getInstance();
-    await prefs.setString('mentor_title', titleController.text);
-    await prefs.setString('mentor_description', descriptionController.text);
-    await prefs.setString('mentor_answer1', answer1Controller.text);
-    await prefs.setString('mentor_answer2', answer2Controller.text);
+    await prefs.setString('mentor_title', titleController.text.toString());
+    await prefs.setString(
+        'mentor_description', descriptionController.text.toString());
+    await prefs.setString('mentor_answer1', answer1Controller.text.toString());
+    await prefs.setString('mentor_answer2', answer2Controller.text.toString());
   }
 
   // SharedPreferences에서 저장된 값 불러오기
@@ -72,13 +74,12 @@ class MentorIntroductionViewModel extends ChangeNotifier {
 
   // 멘토 자기소개 입력 api 호출
   Future<void> saveIntroduction(BuildContext context) async {
+    final prefs = await SharedPreferences.getInstance();
+    final title = prefs.getString('mentor_title') ?? '';
+    final description = prefs.getString('mentor_description') ?? '';
+    final answer1 = prefs.getString('mentor_answer1') ?? '';
+    final answer2 = prefs.getString('mentor_answer2') ?? '';
     try {
-      final prefs = await SharedPreferences.getInstance();
-      final title = prefs.getString('mentor_title') ?? '';
-      final description = prefs.getString('mentor_description') ?? '';
-      final answer1 = prefs.getString('mentor_answer1') ?? '';
-      final answer2 = prefs.getString('mentor_answer2') ?? '';
-
       await _mentorService.patchMentorIntroduction(
           title, description, answer1, answer2);
 

--- a/lib/features/home/mentor_detail/view_models/mentor_introduction_view_model.dart
+++ b/lib/features/home/mentor_detail/view_models/mentor_introduction_view_model.dart
@@ -1,56 +1,91 @@
+import 'dart:developer';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:cogo/data/service/mentor_service.dart';
 import 'package:flutter/material.dart';
 import 'package:cogo/constants/paths.dart';
 import 'package:cogo/common/utils/routing_extension.dart';
 
 class MentorIntroductionViewModel extends ChangeNotifier {
-  // TextEditingController로 각 필드 관리
-  final TextEditingController titleController = TextEditingController();
-  final TextEditingController descriptionController = TextEditingController();
-  final TextEditingController answer1Controller = TextEditingController();
-  final TextEditingController answer2Controller = TextEditingController();
-
-  bool isFormValid = false;
-
   // 각 텍스트 필드의 글자 수를 계산
   int get tittleCharCount => titleController.text.length;
   int get descriptionCharCount => descriptionController.text.length;
   int get answer1CharCount => answer1Controller.text.length;
   int get answer2CharCount => answer2Controller.text.length;
 
+  // 각 텍스트 필드 컨트롤러
+  final TextEditingController titleController = TextEditingController();
+  final TextEditingController descriptionController = TextEditingController();
+  final TextEditingController answer1Controller = TextEditingController();
+  final TextEditingController answer2Controller = TextEditingController();
+
+  final MentorService _mentorService = MentorService();
+  bool isFormValid = false;
+
   MentorIntroductionViewModel() {
-    // 각 컨트롤러에 리스너를 추가하여 값이 변경될 때마다 상태를 확인
     titleController.addListener(_validateFormIntro);
     descriptionController.addListener(_validateFormIntro);
     answer1Controller.addListener(_validateFormQuestion2);
     answer2Controller.addListener(_validateFormQuestion3);
+
+    _loadSavedValues();
   }
 
-  // 텍스트 유효성 확인
   void _validateFormIntro() {
-    isFormValid = titleController.text.isNotEmpty && descriptionController.text.isNotEmpty;
+    isFormValid = titleController.text.isNotEmpty &&
+        descriptionController.text.isNotEmpty;
+    _saveToPreferences();
     notifyListeners();
   }
 
   void _validateFormQuestion2() {
     isFormValid = answer1Controller.text.isNotEmpty;
+    _saveToPreferences();
     notifyListeners();
   }
 
   void _validateFormQuestion3() {
     isFormValid = answer2Controller.text.isNotEmpty;
+    _saveToPreferences();
     notifyListeners();
   }
 
-  // 글자 수 업데이트
   void updateCharCount(TextEditingController controller) {
-    notifyListeners(); // 글자 수 변화를 알림
+    notifyListeners();
   }
 
-  // 데이터를 저장하는 함수
-  void saveIntroduction(BuildContext context) {
-    context.popUntil(Paths.home);
-    //TODO : 데이터 저장 로직 구현
+  Future<void> _saveToPreferences() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString('mentor_title', titleController.text);
+    await prefs.setString('mentor_description', descriptionController.text);
+    await prefs.setString('mentor_answer1', answer1Controller.text);
+    await prefs.setString('mentor_answer2', answer2Controller.text);
+  }
 
+  // SharedPreferences에서 저장된 값 불러오기
+  Future<void> _loadSavedValues() async {
+    final prefs = await SharedPreferences.getInstance();
+    titleController.text = prefs.getString('mentor_title') ?? '';
+    descriptionController.text = prefs.getString('mentor_description') ?? '';
+    answer1Controller.text = prefs.getString('mentor_answer1') ?? '';
+    answer2Controller.text = prefs.getString('mentor_answer2') ?? '';
+  }
+
+  // 멘토 자기소개 입력 api 호출
+  Future<void> saveIntroduction(BuildContext context) async {
+    try {
+      final prefs = await SharedPreferences.getInstance();
+      final title = prefs.getString('mentor_title') ?? '';
+      final description = prefs.getString('mentor_description') ?? '';
+      final answer1 = prefs.getString('mentor_answer1') ?? '';
+      final answer2 = prefs.getString('mentor_answer2') ?? '';
+
+      await _mentorService.patchMentorIntroduction(
+          title, description, answer1, answer2);
+
+      context.popUntil(Paths.home);
+    } catch (e) {
+      log('Failed to save introduction: $e');
+    }
   }
 
   @override


### PR DESCRIPTION
## Issue

- Resolves #45 

## Description
멘토 자기소개 입력 api 연동을 위한 코드입니다.

mentor introduction view model에서 입력한 멘토 자기소개 값을 저장해 api를 호출합니다.
MentorService에서 api 호출 로직을 처리하고 이는 MentorIntroductionResponse 형태로 보냅니다.

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)

## Screenshot

https://github.com/user-attachments/assets/3ca4b949-5295-49e8-8d01-bb380934b31a

