### PR TITLE
[Feature/#54] 커피쳇 가능 시간 불러오기 api

### DIFF
--- a/lib/common/widgets/time_picker.dart
+++ b/lib/common/widgets/time_picker.dart
@@ -16,7 +16,8 @@ class TimePicker extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Center(
+    return Align(
+      alignment: Alignment.topLeft,
       child: Wrap(
         spacing: 10.0,
         runSpacing: 15.0,

--- a/lib/data/dto/response/mentor_possible_date_response.dart
+++ b/lib/data/dto/response/mentor_possible_date_response.dart
@@ -1,11 +1,11 @@
 class MentorPossibleDateResponse {
-  final int possiblDateId;
+  final int possibleDateId;
   final String date;
   final String startTime;
   final String endTime;
 
   MentorPossibleDateResponse({
-    required this.possiblDateId,
+    required this.possibleDateId,
     required this.date,
     required this.startTime,
     required this.endTime,
@@ -13,7 +13,7 @@ class MentorPossibleDateResponse {
 
   factory MentorPossibleDateResponse.fromJson(Map<String, dynamic> json) {
     return MentorPossibleDateResponse(
-      possiblDateId: json['possible_date_id'],
+      possibleDateId: json['possible_date_id'],
       date: json['date'],
       startTime: json['start_time'],
       endTime: json['end_time'],
@@ -22,7 +22,7 @@ class MentorPossibleDateResponse {
 
   Map<String, dynamic> toJson() {
     return {
-      'possible_date_id': possiblDateId,
+      'possible_date_id': possibleDateId,
       'date': date,
       'start_time': startTime,
       'end_time': endTime,

--- a/lib/data/dto/response/mentor_possible_date_response.dart
+++ b/lib/data/dto/response/mentor_possible_date_response.dart
@@ -1,0 +1,31 @@
+class MentorPossibleDateResponse {
+  final int possiblDateId;
+  final String date;
+  final String startTime;
+  final String endTime;
+
+  MentorPossibleDateResponse({
+    required this.possiblDateId,
+    required this.date,
+    required this.startTime,
+    required this.endTime,
+  });
+
+  factory MentorPossibleDateResponse.fromJson(Map<String, dynamic> json) {
+    return MentorPossibleDateResponse(
+      possiblDateId: json['possible_date_id'],
+      date: json['date'],
+      startTime: json['start_time'],
+      endTime: json['end_time'],
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'possible_date_id': possiblDateId,
+      'date': date,
+      'start_time': startTime,
+      'end_time': endTime,
+    };
+  }
+}

--- a/lib/data/service/possibledate_service.dart
+++ b/lib/data/service/possibledate_service.dart
@@ -1,0 +1,47 @@
+import 'package:cogo/constants/constants.dart';
+import 'package:cogo/data/di/api_client.dart';
+import 'package:cogo/data/dto/response/mentor_possible_date_response.dart';
+import 'package:dio/dio.dart';
+import 'package:flutter_config/flutter_config.dart';
+
+class PossibledateService {
+  final ApiClient _apiClient = ApiClient();
+  static const apiVersion = "api/v2/";
+
+  //TODO : 추후 실제 유저 토큰으로 바꿔야 함
+  String token = FlutterConfig.get('mentor_token');
+
+  Future<MentorPossibleDateResponse> getMentorPossibleDates(
+      int mentorId) async {
+    try {
+      final response = await _apiClient.dio.get(
+        '$apiVersion${Apis.possibleDates}/$mentorId',
+        options: Options(
+          extra: {'skipAuthToken': false},
+          headers: {
+            'Authorization': 'Bearer $token',
+          },
+        ),
+      );
+      if (response.statusCode == 200) {
+        final responseData = response.data;
+
+        // JSON 데이터의 content가 null인 경우
+        if (responseData is Map<String, dynamic> &&
+            responseData['content'] != null) {
+          final contentJson = responseData['content'] as Map<String, dynamic>;
+          return MentorPossibleDateResponse.fromJson(contentJson);
+        } else {
+          throw Exception(
+              'Unexpected response format or null content: $responseData');
+        }
+      } else {
+        throw Exception('Failed to fetch mentor details: ${response.data}');
+      }
+    } on DioException catch (e) {
+      throw Exception('Error: ${e.response?.data ?? e.message}');
+    } catch (e) {
+      throw Exception('An unexpected error occurred: $e');
+    }
+  }
+}

--- a/lib/data/service/possibledate_service.dart
+++ b/lib/data/service/possibledate_service.dart
@@ -1,6 +1,7 @@
+import 'dart:developer';
+
 import 'package:cogo/constants/constants.dart';
 import 'package:cogo/data/di/api_client.dart';
-import 'package:cogo/data/dto/response/mentor_possible_date_response.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_config/flutter_config.dart';
 
@@ -11,7 +12,8 @@ class PossibledateService {
   //TODO : 추후 실제 유저 토큰으로 바꿔야 함
   String token = FlutterConfig.get('mentor_token');
 
-  Future<MentorPossibleDateResponse> getMentorPossibleDates(
+  // 커피쳇 가능 시간 불러오기 api
+  Future<List<Map<String, dynamic>>> getMentorPossibleDates(
       int mentorId) async {
     try {
       final response = await _apiClient.dio.get(
@@ -26,22 +28,18 @@ class PossibledateService {
       if (response.statusCode == 200) {
         final responseData = response.data;
 
-        // JSON 데이터의 content가 null인 경우
-        if (responseData is Map<String, dynamic> &&
-            responseData['content'] != null) {
-          final contentJson = responseData['content'] as Map<String, dynamic>;
-          return MentorPossibleDateResponse.fromJson(contentJson);
+        if (responseData['content'] is List) {
+          return List<Map<String, dynamic>>.from(responseData['content']);
         } else {
-          throw Exception(
-              'Unexpected response format or null content: $responseData');
+          throw Exception('Unexpected response format');
         }
       } else {
-        throw Exception('Failed to fetch mentor details: ${response.data}');
+        throw Exception(
+            'Failed to fetch mentor possible dates: ${response.statusCode}');
       }
-    } on DioException catch (e) {
-      throw Exception('Error: ${e.response?.data ?? e.message}');
-    } catch (e) {
-      throw Exception('An unexpected error occurred: $e');
+    } on DioError catch (e) {
+      log('Dio Error: ${e.response?.data ?? e.message}');
+      throw Exception('Dio Error: ${e.response?.data ?? e.message}');
     }
   }
 }

--- a/lib/domain/entity/mentor_possible_date_entity.dart
+++ b/lib/domain/entity/mentor_possible_date_entity.dart
@@ -1,38 +1,43 @@
+import 'package:cogo/data/dto/response/mentor_possible_date_response.dart';
+
 class MentorPossibleDateEntity {
+  final int possibleDateId;
   final DateTime date;
   final String startTime;
   final String endTime;
 
   MentorPossibleDateEntity({
+    required this.possibleDateId,
     required this.date,
     required this.startTime,
     required this.endTime,
   });
 
-  factory MentorPossibleDateEntity.fromJson(Map<String, dynamic> json) {
+  factory MentorPossibleDateEntity.fromResponse(
+      MentorPossibleDateResponse response) {
     return MentorPossibleDateEntity(
-      date: DateTime.parse(json['date']),
-      startTime: _formatTime(json['start_time']),
-      endTime: _formatTime(json['end_time']),
+      possibleDateId: response.possibleDateId,
+      date: DateTime.parse(response.date),
+      startTime: _formatTime(response.startTime),
+      endTime: _formatTime(response.endTime),
     );
   }
 
   Map<String, dynamic> toJson() {
     return {
+      'possible_date_id': possibleDateId,
       'date': date.toIso8601String(),
       'start_time': startTime,
       'end_time': endTime,
     };
   }
 
-  // 시간 문자열에서 초를 제거 메서드
+  // 초 제거 메서드
   static String _formatTime(String time) {
     return time.split(':').sublist(0, 2).join(':');
   }
 
-  // 날짜 포맷을 위한 메서드
   String get formattedDate => '${date.year}-${date.month}-${date.day}';
 
-  // 시간대를 결합한 포맷
   String get formattedTimeSlot => '$startTime ~ $endTime';
 }

--- a/lib/domain/entity/mentor_possible_date_entity.dart
+++ b/lib/domain/entity/mentor_possible_date_entity.dart
@@ -1,0 +1,38 @@
+class MentorPossibleDateEntity {
+  final DateTime date;
+  final String startTime;
+  final String endTime;
+
+  MentorPossibleDateEntity({
+    required this.date,
+    required this.startTime,
+    required this.endTime,
+  });
+
+  factory MentorPossibleDateEntity.fromJson(Map<String, dynamic> json) {
+    return MentorPossibleDateEntity(
+      date: DateTime.parse(json['date']),
+      startTime: _formatTime(json['start_time']),
+      endTime: _formatTime(json['end_time']),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'date': date.toIso8601String(),
+      'start_time': startTime,
+      'end_time': endTime,
+    };
+  }
+
+  // 시간 문자열에서 초를 제거 메서드
+  static String _formatTime(String time) {
+    return time.split(':').sublist(0, 2).join(':');
+  }
+
+  // 날짜 포맷을 위한 메서드
+  String get formattedDate => '${date.year}-${date.month}-${date.day}';
+
+  // 시간대를 결합한 포맷
+  String get formattedTimeSlot => '$startTime ~ $endTime';
+}

--- a/lib/domain/entity/mentor_possible_date_entity.dart
+++ b/lib/domain/entity/mentor_possible_date_entity.dart
@@ -37,7 +37,5 @@ class MentorPossibleDateEntity {
     return time.split(':').sublist(0, 2).join(':');
   }
 
-  String get formattedDate => '${date.year}-${date.month}-${date.day}';
-
   String get formattedTimeSlot => '$startTime ~ $endTime';
 }

--- a/lib/features/home/apply/view_models/schedule_view_model.dart
+++ b/lib/features/home/apply/view_models/schedule_view_model.dart
@@ -1,4 +1,5 @@
 import 'package:cogo/constants/constants.dart';
+import 'package:cogo/data/dto/response/mentor_possible_date_response.dart';
 import 'package:cogo/domain/entity/mentor_possible_date_entity.dart';
 import 'package:flutter/material.dart';
 import 'package:cogo/data/service/possibledate_service.dart';
@@ -16,14 +17,14 @@ class ScheduleViewModel extends ChangeNotifier {
 
   // 멘토 가능한 시간 api 호출
   Future<void> fetchMentorPossibleDates(int mentorId) async {
-    print("사용자가 멘토가이디: $mentorId");
     try {
+      // API 호출
       final response =
           await _possibledateService.getMentorPossibleDates(mentorId);
 
-      // 응답 데이터를 MentorPossibleDate 엔티티로 변환
       mentorPossibleDates = response
-          .map((json) => MentorPossibleDateEntity.fromJson(json))
+          .map((json) => MentorPossibleDateEntity.fromResponse(
+              MentorPossibleDateResponse.fromJson(json)))
           .toList();
 
       availableDates =

--- a/lib/features/home/apply/view_models/schedule_view_model.dart
+++ b/lib/features/home/apply/view_models/schedule_view_model.dart
@@ -19,7 +19,6 @@ class ScheduleViewModel extends ChangeNotifier {
   // 멘토 가능한 시간 API 호출
   Future<void> fetchMentorPossibleDates(int mentorId) async {
     try {
-      // API 호출
       final response =
           await _possibledateService.getMentorPossibleDates(mentorId);
 

--- a/lib/features/home/apply/views/schedule_screen.dart
+++ b/lib/features/home/apply/views/schedule_screen.dart
@@ -1,16 +1,18 @@
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'package:cogo/features/home/apply/view_models/schedule_view_model.dart';
 import 'package:cogo/common/widgets/widgets.dart';
-import 'package:cogo/constants/constants.dart';
 
 class ScheduleScreen extends StatelessWidget {
-  const ScheduleScreen({super.key});
+  final int mentorId;
+
+  const ScheduleScreen({super.key, required this.mentorId});
 
   @override
   Widget build(BuildContext context) {
     return ChangeNotifierProvider(
-      create: (_) => ScheduleViewModel(),
+      create: (_) => ScheduleViewModel()..fetchMentorPossibleDates(mentorId),
       child: Scaffold(
         backgroundColor: Colors.white,
         body: SafeArea(
@@ -48,7 +50,7 @@ class ScheduleScreen extends StatelessWidget {
                                 selectedTimeSlot: viewModel.selectedTimeSlot,
                                 onTimeSlotSelected:
                                     viewModel.onTimeSlotSelected,
-                                timeSlots: viewModel.timeSlots,
+                                timeSlots: viewModel.filteredTimeSlots,
                               ),
                             ),
                             const SizedBox(height: 20),

--- a/lib/features/home/apply/views/schedule_screen.dart
+++ b/lib/features/home/apply/views/schedule_screen.dart
@@ -46,12 +46,21 @@ class ScheduleScreen extends StatelessWidget {
                                 color: CogoColor.systemGray01, thickness: 1),
                             Padding(
                               padding: const EdgeInsets.all(10.0),
-                              child: TimePicker(
-                                selectedTimeSlot: viewModel.selectedTimeSlot,
-                                onTimeSlotSelected:
-                                    viewModel.onTimeSlotSelected,
-                                timeSlots: viewModel.filteredTimeSlots,
-                              ),
+                              child: viewModel.filteredTimeSlots.isEmpty
+                                  ? Center(
+                                      child: Text(
+                                        '해당 날짜에는 가능한 시간대가 없어요',
+                                        style: CogoTextStyle.body14.copyWith(
+                                            color: CogoColor.systemGray03),
+                                      ),
+                                    )
+                                  : TimePicker(
+                                      selectedTimeSlot:
+                                          viewModel.selectedTimeSlot,
+                                      onTimeSlotSelected:
+                                          viewModel.onTimeSlotSelected,
+                                      timeSlots: viewModel.filteredTimeSlots,
+                                    ),
                             ),
                             const SizedBox(height: 20),
                           ],

--- a/lib/features/home/home/view_model/home_view_model.dart
+++ b/lib/features/home/home/view_model/home_view_model.dart
@@ -8,7 +8,7 @@ import 'package:cogo/data/service/mentor_service.dart';
 
 class HomeViewModel extends ChangeNotifier {
   String? selectedRole = "mentor";
-  bool isIntroductionComplete = false; // 자기소개 완료 여부를 저장
+  bool isIntroductionComplete = true; // 자기소개 완료 여부를 저장
 
   final MentorService _mentorService = MentorService(); // MentorService 객체 생성
 

--- a/lib/features/home/profile/view/profile_detail_screen.dart
+++ b/lib/features/home/profile/view/profile_detail_screen.dart
@@ -104,7 +104,7 @@ class ProfileDetailScreen extends StatelessWidget {
                       const SizedBox(height: 30),
                       ElevatedButton(
                         onPressed: () {
-                          viewModel.applyForCogo(context);
+                          viewModel.applyForCogo(context, mentorId);
                         },
                         style: ElevatedButton.styleFrom(
                           backgroundColor: CogoColor.main,

--- a/lib/features/home/profile/view_model/profile_detail_view_model.dart
+++ b/lib/features/home/profile/view_model/profile_detail_view_model.dart
@@ -8,7 +8,7 @@ import 'package:go_router/go_router.dart';
 
 class ProfileDetailViewModel extends ChangeNotifier {
   MentorDetailEntity? profile;
-  bool isLoading = true; // 로딩 상태를 나타내는 변수
+  bool isLoading = true;
   final MentorService _mentorService = MentorService();
 
   ProfileDetailViewModel(int mentorId) {
@@ -28,7 +28,10 @@ class ProfileDetailViewModel extends ChangeNotifier {
     }
   }
 
-  void applyForCogo(BuildContext context) {
-    context.push(Paths.schedule);
+  void applyForCogo(BuildContext context, int mentorId) {
+    context.push(
+      Paths.schedule,
+      extra: {'mentorId': mentorId},
+    );
   }
 }

--- a/lib/route/routes.dart
+++ b/lib/route/routes.dart
@@ -127,10 +127,12 @@ final AppRouter = GoRouter(
     ),
     GoRoute(
       path: Paths.schedule,
-      pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const ScheduleScreen(),
-      ),
+      builder: (context, state) {
+        final extra = state.extra as Map<String, dynamic>;
+        final mentorId = extra['mentorId'] as int;
+
+        return ScheduleScreen(mentorId: mentorId);
+      },
     ),
     GoRoute(
       path: Paths.memo,
@@ -228,69 +230,6 @@ final AppRouter = GoRouter(
       pageBuilder: (context, state) => MaterialPage(
         key: state.pageKey,
         child: const MentorTimeSettingScreen(),
-      ),
-    ),
-    GoRoute(
-      path: Paths.search,
-      pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const SearchScreen(),
-      ),
-    ),
-    GoRoute(
-      path: Paths.schedule,
-      pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const ScheduleScreen(),
-      ),
-    ),
-    GoRoute(
-      path: Paths.memo,
-      pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const MemoScreen(),
-      ),
-    ),
-    GoRoute(
-      path: Paths.matching,
-      pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const MatchingScreen(),
-      ),
-    ),
-    GoRoute(
-      path: Paths.receivedCogo,
-      pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const ReceivedCogoScreen(),
-      ),
-    ),
-    GoRoute(
-      path: Paths.receivedCogoDetail,
-      pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const ReceivedCogoDetailScreen(),
-      ),
-    ),
-    GoRoute(
-      path: Paths.successedCogo,
-      pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const SuccessedCogoScreen(),
-      ),
-    ),
-    GoRoute(
-      path: Paths.successedCogoDetail,
-      pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const SuccessedCogoDetailScreen(),
-      ),
-    ),
-    GoRoute(
-      path: Paths.mentorIntroduction,
-      pageBuilder: (context, state) => MaterialPage(
-        key: state.pageKey,
-        child: const MentorIntroductionScreen(),
       ),
     ),
     StatefulShellRoute.indexedStack(


### PR DESCRIPTION
## Issue

- Resolves #54 

## Description

**mentorId로 커피쳇 가능 시간 불러오기 api 연동 작업을 진행하였습니다**

### API 호출
1. mentor possible date response에서 응답 받음
2. mentor possible date entity에서 응답 변환 작업 수행
- date -> DateTime으로 변환
- startTime, endTime -> _formatTime를 사용해 응답값에 초 부분 삭제
- formattedTimeSlot -> startTime, endTime을 ui에 보여줄 시간 형식으로 변환
3. schedule view model애서 screen 진입시 해당 api 호출
- fetchMentorPossibleDates에서 response를 entity로 변환
- availableDates에 응답값에서의 date와 선책된 date picker의 날짜 비교해서 필터링한 값 할당
- filteredTimeSlots을 사용해 선택된 날짜에 맞는 시간대 목록(time picker에 전달) 할당 
4. 사용자가 시간 선택 후 saveSelection을 호출하여 다음 cogo 신청을 위한 possibleDateId전달 및 라우팅

## Check List

- [x]  PR 제목을 커밋 규칙에 맞게 작성
- [x]  PR에 해당되는 Issue를 연결 완료
- [x]  적절한 라벨 설정
- [x]  작업한 사람 모두를 Assign
- [x]  작업한 팀에게 Code Review 요청 (Reviewer 등록)

## Screenshot

https://github.com/user-attachments/assets/a4e087f9-69f2-48e5-a532-3210566b5883






