### PR TITLE
[Fix] 마이페이지에서 멘토 자기소개 수정 뷰 라우팅 오류 및 기존 자기소개 안불러와지는 오류 수정

### DIFF
--- a/lib/data/dto/response/mentor_introduction_response.dart
+++ b/lib/data/dto/response/mentor_introduction_response.dart
@@ -6,11 +6,11 @@ part 'mentor_introduction_response.g.dart';
 @freezed
 class MentorIntroductionResponse with _$MentorIntroductionResponse {
   const factory MentorIntroductionResponse({
-    @JsonKey(name: 'introduction_title') required String introductionTitle,
+    @JsonKey(name: 'introduction_title') required String? introductionTitle,
     @JsonKey(name: 'introduction_description')
-    required String introductionDescription,
-    @JsonKey(name: 'introduction_answer1') required String introductionAnswer1,
-    @JsonKey(name: 'introduction_answer2') required String introductionAnswer2,
+    required String? introductionDescription,
+    @JsonKey(name: 'introduction_answer1') required String? introductionAnswer1,
+    @JsonKey(name: 'introduction_answer2') required String? introductionAnswer2,
   }) = _MentorIntroductionResponse;
 
   factory MentorIntroductionResponse.fromJson(Map<String, dynamic> json) =>

--- a/lib/features/mypage/mentor_introduce/my_mentor_introduce_view_model.dart
+++ b/lib/features/mypage/mentor_introduce/my_mentor_introduce_view_model.dart
@@ -66,7 +66,7 @@ class MyMentorIntroductionViewModel extends ChangeNotifier {
       var response = await mentorService.fetchMentorIntroduction();
       var data = MyMentorEntity.fromResponse(response);
 
-      introController.text = data.introductionAnswer1.toString();
+      introController.text = data.introductionAnswer1;
       descriptionController.text = data.introductionDescription;
       question1Controller.text = data.introductionAnswer1;
       question2Controller.text = data.introductionAnswer2;

--- a/lib/route/routes.dart
+++ b/lib/route/routes.dart
@@ -223,7 +223,7 @@ final AppRouter = GoRouter(
       path: Paths.myMentorIntroduce,
       pageBuilder: (context, state) => MaterialPage(
         key: state.pageKey,
-        child: const MentorIntroductionScreen(),
+        child: const MyMentorIntroductionScreen(),
       ),
     ),
     GoRoute(


### PR DESCRIPTION
## Issue

- Resolves # N/A

## Description
<!-- 어떤 기능을 구현했나요?    
기존 기능에서 어떤 점이 달라졌나요?  
자세한 로직이 필요하다면 함께 적어주세요!  
코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!   -->

- 마이페이지에서 멘토 자기소개 수정 뷰 라우팅 오류 (4항목이 다 따로 있는 뷰로 라우팅 되었었음)
- 기존 자기소개 안불러와지는 오류가 있어서 수정함
  -  Exception: An unexpected error occurred: type 'Null' is not a subtype of type 'String' in type cast
  - toString()을 제거하니 잘 바인딩 됨
