### PR TITLE
[Fix/#116] 비동기 처리로 회원탈퇴 오류 수정

### DIFF
--- a/lib/data/service/user_service.dart
+++ b/lib/data/service/user_service.dart
@@ -196,10 +196,9 @@ class UserService {
   Future<void> signOut() async {
     try {
       final response = await _apiClient.dio.delete(
-        options: Options(
-          extra: {'skipAuthToken': false}, //토큰 해제를 하지 마라
-        ),
         apiVersion + Apis.user,
+        options: Options(extra: {'skipAuthToken': false} //토큰 해제를 하지 마라
+            ),
       );
       if (response.statusCode == 200) {
         log("탈퇴 성공");

--- a/lib/features/mypage/mypage_view_model.dart
+++ b/lib/features/mypage/mypage_view_model.dart
@@ -47,9 +47,8 @@ class MypageViewModel extends ChangeNotifier {
   }
 
   Future<void> signOut(BuildContext context) async {
-    _secureStorage.deleteAllData();
-    userService.signOut();
-    context.go(Paths.login);
+    await userService.signOut();
+    await _secureStorage.deleteAllData();
   }
 
   void _updateState({


### PR DESCRIPTION
## Issue

- Resolves #116

## Description
<!-- 어떤 기능을 구현했나요?    
기존 기능에서 어떤 점이 달라졌나요?  
자세한 로직이 필요하다면 함께 적어주세요!  
코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!   -->

- 기존 코드에서 비동기 처리가 안되어 먼저 토큰을 삭제하고 회원탈퇴 api를 호출하는 오류가 있었습니다
- 이에 먼저 회원탈퇴 api를 완료 후 로컬에 저장해놓은 토큰을 삭제하는 로직으로 수정하여 오류 처리 완료하였습니다. 

## Screenshot
<!--기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요  -->

## 💬 리뷰 요구사항(선택)
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 고민사항도 적어주세요.  -->
