### PR TITLE
[Fix/#121] 멘토 자기소개 다이얼로그 구별 방식 변경

### DIFF
--- a/lib/common/navigator/bottom_navigation_bar.dart
+++ b/lib/common/navigator/bottom_navigation_bar.dart
@@ -1,3 +1,5 @@
+import 'package:cogo/common/widgets/atoms/texts/styles.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
@@ -11,13 +13,6 @@ class ScaffoldWithNestedNavigation extends StatelessWidget {
   }) : super(key: key ?? const ValueKey('ScaffoldWithNestedNavigation'));
 
   final StatefulNavigationShell navigationShell;
-
-  void _goBranch(int index) {
-    navigationShell.goBranch(
-      index,
-      initialLocation: index == navigationShell.currentIndex,
-    );
-  }
 
   Widget _buildIcon(String assetPath, bool isSelected) {
     return ColorFiltered(
@@ -48,14 +43,8 @@ class ScaffoldWithNestedNavigation extends StatelessWidget {
               backgroundColor: Colors.black,
               selectedItemColor: Colors.white,
               unselectedItemColor: const Color(0xFF626262),
-              selectedLabelStyle: const TextStyle(
-                fontFamily: 'PretendardRegular',
-                fontSize: 12,
-              ),
-              unselectedLabelStyle: const TextStyle(
-                fontFamily: 'PretendardRegular',
-                fontSize: 12,
-              ),
+              selectedLabelStyle: CogoTextStyle.bodyR12,
+              unselectedLabelStyle: CogoTextStyle.bodyR12,
               items: [
                 BottomNavigationBarItem(
                   icon: _buildIcon(

--- a/lib/common/navigator/bottom_navigation_bar_view_model.dart
+++ b/lib/common/navigator/bottom_navigation_bar_view_model.dart
@@ -1,3 +1,5 @@
+import 'package:cogo/common/enums/role.dart';
+import 'package:cogo/constants/constants.dart';
 import 'package:cogo/data/repository/local/secure_storage_repository.dart';
 import 'package:cogo/features/home/home_view_model.dart';
 import 'package:cogo/features/mypage/profile_management/mentor_introduction_screen.dart';
@@ -27,10 +29,11 @@ class BottomNavigationViewModel extends ChangeNotifier {
     // HomeViewModel에 접근해서 role과 isIntroductionComplete 값 확인
     final homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
 
+    /// 코고 탭 진입시에 멘토 자기소개 완료했는지 판단
+    homeViewModel.loadPreferences();
     if (index == 1 &&
-        role == 'MENTOR' &&
-        homeViewModel.isIntroductionComplete == false) {
-      // 조건이 만족하면 다이얼로그를 띄움
+        role == Role.ROLE_MENTOR.name &&
+        homeViewModel.shouldShowDialog) {
       _showMentorProfileDialog(context);
     } else {
       // 페이지 이동 처리
@@ -55,30 +58,17 @@ class BottomNavigationViewModel extends ChangeNotifier {
   void _showMentorProfileDialog(BuildContext context) {
     showDialog(
       context: context,
-      builder: (BuildContext context) {
-        return OneButtonDialog(
-          title: "멘토 활동을 시작하려면\n프로필 작성을 완료해주세요",
-          subtitle: '입력하신 정보는 하단의 MY에서 수정이 가능해요',
-          imagePath: 'assets/icons/3d_img/heart.png',
-          buttonText: '멘토 프로필 작성하기',
-          onPressed: () => Navigator.of(context).push(_createRoute()),
-        );
-      },
-    );
-  }
-
-  Route _createRoute() {
-    return PageRouteBuilder(
-      pageBuilder: (context, animation, secondaryAnimation) =>
-          const MentorIntroductionScreen(),
-      transitionsBuilder: (context, animation, secondaryAnimation, child) {
-        var tween = Tween(begin: const Offset(0.0, 1.0), end: Offset.zero)
-            .chain(CurveTween(curve: Curves.ease));
-        return SlideTransition(
-          position: animation.drive(tween),
-          child: child,
-        );
-      },
+      barrierDismissible: false,
+      builder: (context) => OneButtonDialog(
+        title: "멘토 활동을 시작하려면\n프로필 작성을 완료해주세요",
+        subtitle: "입력하신 정보는 하단의 MY에서 수정이 가능해요",
+        imagePath: "assets/icons/3d_img/heart.png",
+        buttonText: "멘토 프로필 작성하기",
+        onPressed: () {
+          Navigator.of(context).pop();
+          Future.microtask(() => context.push(Paths.mentorIntroduction));
+        },
+      ),
     );
   }
 }

--- a/lib/common/navigator/bottom_navigation_bar_view_model.dart
+++ b/lib/common/navigator/bottom_navigation_bar_view_model.dart
@@ -17,23 +17,29 @@ class BottomNavigationViewModel extends ChangeNotifier {
 
   int get selectedIndex => _selectedIndex;
 
-  BottomNavigationViewModel(this.goRouter) {
-    _loadPreferences();
+  bool shouldShowDialog = false;
+
+  BottomNavigationViewModel(this.goRouter);
+
+  void initialize(BuildContext context) {
+    _loadPreferences(context);
   }
 
-  void _loadPreferences() async {
+  void _loadPreferences(BuildContext context) async {
     role = await _secureStorage.readRole();
+
+    final homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
+    homeViewModel.loadPreferences();
+    shouldShowDialog = homeViewModel.shouldShowDialog;
+
+    notifyListeners();
   }
 
   void setIndex(int index, BuildContext context) {
     // HomeViewModel에 접근해서 role과 isIntroductionComplete 값 확인
-    final homeViewModel = Provider.of<HomeViewModel>(context, listen: false);
 
-    /// 코고 탭 진입시에 멘토 자기소개 완료했는지 판단
-    homeViewModel.loadPreferences();
-    if (index == 1 &&
-        role == Role.ROLE_MENTOR.name &&
-        homeViewModel.shouldShowDialog) {
+    /// 코고 탭 진입시에 멘토 자기소개 완료했는지 판단(
+    if (index == 1 && role == Role.ROLE_MENTOR.name && shouldShowDialog) {
       _showMentorProfileDialog(context);
     } else {
       // 페이지 이동 처리

--- a/lib/common/widgets/atoms/texts/styles.dart
+++ b/lib/common/widgets/atoms/texts/styles.dart
@@ -91,4 +91,10 @@ final class CogoTextStyle {
     fontSize: 16,
     color: CogoColor.systemGray05,
   );
+
+  static const TextStyle bodyR12 = TextStyle(
+    fontFamily: "PretendardRegular",
+    fontSize: 12,
+    color: CogoColor.systemGray05,
+  );
 }

--- a/lib/data/repository/local/secure_storage_repository.dart
+++ b/lib/data/repository/local/secure_storage_repository.dart
@@ -62,18 +62,6 @@ class SecureStorageRepository {
     await _storage.write(key: "club", value: club);
   }
 
-  /// 멘토 자기소개 입력 여부
-  Future<void> saveIntroductionCompleted(bool value) async {
-    await _storage.write(
-        key: "introduction_completed", value: value.toString());
-  }
-
-  Future<bool> readIntroductionCompleted() async {
-    final result = await _storage.read(key: "introduction_completed");
-    if (result == null) return false; // 저장된 값이 없으면 false
-    return result.toLowerCase() == 'true'; // 저장된 값이 'true'면 true, 아니면 false
-  }
-
   ///모든 데이터 삭제
   Future<void> deleteAllData() async {
     await _storage.deleteAll();

--- a/lib/features/auth/signup/completion/completion_screen.dart
+++ b/lib/features/auth/signup/completion/completion_screen.dart
@@ -61,7 +61,6 @@ class CompletionScreen extends StatelessWidget {
                             isClickable: true,
                             onPressed: () async {
                               await viewModel.refreshToken();
-                              await viewModel.setIntroductionComplete();
                               context.go(Paths.home);
                             },
                             size: BasicButtonSize.LARGE,

--- a/lib/features/auth/signup/completion/completion_view_model.dart
+++ b/lib/features/auth/signup/completion/completion_view_model.dart
@@ -23,21 +23,6 @@ class CompletionViewModel extends ChangeNotifier {
     await authService.reissueToken();
   }
 
-  /// 자기소개 입력 여부
-  Future<void> setIntroductionComplete() async {
-    if (role == Role.ROLE_MENTOR.name) {
-      await _secureStorage.saveIntroductionCompleted(false);
-    } else {
-      await _secureStorage.saveIntroductionCompleted(true);
-    }
-
-    log("롤은요 : $role");
-    final isCompletement = await _secureStorage.readIntroductionCompleted();
-    log("자기소개 완료 : $isCompletement");
-
-    notifyListeners();
-  }
-
   void _loadPreferences() async {
     role = await _secureStorage.readRole();
     isLoading = false;

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -34,12 +34,12 @@ class _HomeScreenState extends State<HomeScreen>
       final viewModel = Provider.of<HomeViewModel>(context, listen: false);
 
       // ViewModel 초기화 완료될 때까지 기다림
-      while (viewModel.isIntroductionComplete == null) {
-        await Future.delayed(Duration(milliseconds: 10));
+      while (!viewModel.isInitialized) {
+        await Future.delayed(Duration(milliseconds: 50));
       }
 
       // 자기소개 안 했으면 다이얼로그 띄우기
-      if (viewModel.isIntroductionComplete == false) {
+      if (viewModel.shouldShowDialog) {
         showDialog(
           context: context,
           barrierDismissible: false,
@@ -49,7 +49,8 @@ class _HomeScreenState extends State<HomeScreen>
             imagePath: "assets/icons/3d_img/heart.png",
             buttonText: "멘토 프로필 작성하기",
             onPressed: () {
-              context.push(Paths.mentorIntroduction);
+              Navigator.of(context).pop();
+              Future.microtask(() => context.push(Paths.mentorIntroduction));
             },
           ),
         );

--- a/lib/features/home/home_view_model.dart
+++ b/lib/features/home/home_view_model.dart
@@ -16,6 +16,10 @@ class HomeViewModel extends ChangeNotifier {
   final MentorService mentorService = GetIt.instance<MentorService>();
   String? role;
 
+  bool _shouldShowDialog = false;
+  bool get shouldShowDialog => _shouldShowDialog;
+  bool isInitialized = false;
+
   HomeViewModel() {
     _loadPreferences();
   }
@@ -23,10 +27,13 @@ class HomeViewModel extends ChangeNotifier {
   void _loadPreferences() async {
     role = await _secureStorage.readRole();
 
-    /// 멘토 롤일 경우 다이얼로그 띄우기
     if (role == Role.ROLE_MENTOR.name) {
       await fetchIntroductionData();
+      if (isIntroductionComplete == false) {
+        _shouldShowDialog = true;
+      }
     }
+    isInitialized = true;
     notifyListeners();
   }
 

--- a/lib/features/home/home_view_model.dart
+++ b/lib/features/home/home_view_model.dart
@@ -21,10 +21,10 @@ class HomeViewModel extends ChangeNotifier {
   bool isInitialized = false;
 
   HomeViewModel() {
-    _loadPreferences();
+    loadPreferences();
   }
 
-  void _loadPreferences() async {
+  void loadPreferences() async {
     role = await _secureStorage.readRole();
 
     if (role == Role.ROLE_MENTOR.name) {

--- a/lib/features/home/home_view_model.dart
+++ b/lib/features/home/home_view_model.dart
@@ -1,8 +1,10 @@
 import 'dart:developer';
+import 'package:cogo/common/enums/role.dart';
 import 'package:cogo/constants/paths.dart';
 import 'package:cogo/data/repository/local/secure_storage_repository.dart';
 import 'package:cogo/data/service/mentor_service.dart';
 import 'package:cogo/domain/entity/mentor_part_entity.dart';
+import 'package:cogo/domain/entity/my_mentor_entity.dart';
 import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
@@ -20,7 +22,11 @@ class HomeViewModel extends ChangeNotifier {
 
   void _loadPreferences() async {
     role = await _secureStorage.readRole();
-    isIntroductionComplete = await _secureStorage.readIntroductionCompleted();
+
+    /// 멘토 롤일 경우 다이얼로그 띄우기
+    if (role == Role.ROLE_MENTOR.name) {
+      await fetchIntroductionData();
+    }
     notifyListeners();
   }
 
@@ -34,6 +40,24 @@ class HomeViewModel extends ChangeNotifier {
       log('Error fetching mentor details: $error');
     } finally {
       notifyListeners();
+    }
+  }
+
+  /// 토큰으로 멘토 자기소개 4개 호출 (멘토 자기소개 다이얼로그 관리 용)
+  Future<void> fetchIntroductionData() async {
+    try {
+      var response = await mentorService.fetchMentorIntroduction();
+      log('${response.introductionTitle}');
+      if (response.introductionTitle == null) {
+        isIntroductionComplete = false;
+      } else {
+        log('Successed to loading introduction');
+        isIntroductionComplete = true;
+      }
+
+      notifyListeners();
+    } catch (e) {
+      log('Failed to loading introduction: $e');
     }
   }
 

--- a/lib/features/home/mentor_detail/mentor_introduction_view_model.dart
+++ b/lib/features/home/mentor_detail/mentor_introduction_view_model.dart
@@ -34,13 +34,6 @@ class MentorIntroductionViewModel extends ChangeNotifier {
     _loadSavedValues();
   }
 
-  Future<void> setMentorIntroductionCompletion() async {
-    await _secureStorage.saveIntroductionCompleted(true);
-    final isComplete = await _secureStorage.readIntroductionCompleted();
-    log('완료 성공 ? : $isComplete');
-    notifyListeners();
-  }
-
   void _validateFormIntro() {
     isFormValid = titleController.text.isNotEmpty &&
         descriptionController.text.isNotEmpty;

--- a/lib/features/home/mentor_detail/views/mentor_detail_completion_screen.dart
+++ b/lib/features/home/mentor_detail/views/mentor_detail_completion_screen.dart
@@ -1,6 +1,7 @@
 import 'package:cogo/common/widgets/components/header.dart';
 import 'package:cogo/common/widgets/widgets.dart';
 import 'package:cogo/constants/paths.dart';
+import 'package:cogo/features/home/home_view_model.dart';
 import 'package:cogo/features/home/mentor_detail/mentor_introduction_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
@@ -47,6 +48,10 @@ class MentorDetailCompletionScreen extends StatelessWidget {
                       size: BasicButtonSize.LARGE,
                       onPressed: () async {
                         await viewModel.setMentorIntroductionCompletion();
+
+                        final homeViewModel =
+                            Provider.of<HomeViewModel>(context, listen: false);
+                        await homeViewModel.fetchIntroductionData();
                         context.go(Paths.home);
                       },
                     );

--- a/lib/features/home/mentor_detail/views/mentor_detail_completion_screen.dart
+++ b/lib/features/home/mentor_detail/views/mentor_detail_completion_screen.dart
@@ -47,8 +47,6 @@ class MentorDetailCompletionScreen extends StatelessWidget {
                       isClickable: true,
                       size: BasicButtonSize.LARGE,
                       onPressed: () async {
-                        await viewModel.setMentorIntroductionCompletion();
-
                         final homeViewModel =
                             Provider.of<HomeViewModel>(context, listen: false);
                         await homeViewModel.fetchIntroductionData();

--- a/lib/features/mypage/mentor_time_checking/mentor_time_checking_screen.dart
+++ b/lib/features/mypage/mentor_time_checking/mentor_time_checking_screen.dart
@@ -10,10 +10,13 @@ class MentorTimeCheckingScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    final extra = GoRouterState.of(context).extra as Map?;
+    final isIntroductionComplete =
+        extra?['isIntroductionComplete'] as bool? ?? false;
+
     return ChangeNotifierProvider(
       create: (_) {
         final viewModel = MentorTimeCheckingViewModel();
-        viewModel.loadMentorIntroductionStatus();
         viewModel.getPossibleDates();
         return viewModel;
       },
@@ -74,16 +77,14 @@ class MentorTimeCheckingScreen extends StatelessWidget {
                         alignment: Alignment.bottomCenter,
                         child: BasicButton(
                           onPressed: () {
-                            if (viewModel.isMentorIntroductionComplete) {
+                            if (isIntroductionComplete) {
                               Navigator.of(context)
                                   .popUntil((route) => route.isFirst);
                             } else {
                               context.push(Paths.mentorDetailCompletion);
                             }
                           },
-                          text: viewModel.isMentorIntroductionComplete
-                              ? '수정하기'
-                              : '완료',
+                          text: isIntroductionComplete ? '수정하기' : '완료',
                           isClickable: true,
                         ),
                       ),

--- a/lib/features/mypage/mentor_time_checking/mentor_time_checking_view_model.dart
+++ b/lib/features/mypage/mentor_time_checking/mentor_time_checking_view_model.dart
@@ -4,28 +4,20 @@ import 'package:cogo/common/utils/routing_extension.dart';
 import 'package:cogo/constants/constants.dart';
 import 'package:cogo/data/dto/response/mentor_possible_date_response.dart';
 import 'package:cogo/data/repository/local/secure_storage_repository.dart';
+import 'package:cogo/data/service/mentor_service.dart';
 import 'package:cogo/data/service/possibledate_service.dart';
 import 'package:cogo/domain/entity/mentor_possible_date_entity.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 
 class MentorTimeCheckingViewModel extends ChangeNotifier {
   final PossibledateService _possibledateService = PossibledateService();
+  final MentorService mentorService = GetIt.instance<MentorService>();
   List<MentorPossibleDateEntity> mentorPossibleDates = []; // 멘토 가능한 날짜 및 시간대 목록
   Map<DateTime, List<MentorPossibleDateEntity>> groupedDates =
       {}; // 날짜별로 그룹화된 시간대 목록
   List<DateTime> sortedDates = []; // 정렬된 날짜 목록
-  final SecureStorageRepository _secureStorage = SecureStorageRepository();
-  bool isMentorIntroductionComplete = false;
-
-  /// 자기소개 작성 여부 확인
-  Future<void> loadMentorIntroductionStatus() async {
-    isMentorIntroductionComplete =
-        await _secureStorage.readIntroductionCompleted();
-
-    log("완료 설정 : $isMentorIntroductionComplete");
-    notifyListeners();
-  }
 
   Future<void> getPossibleDates() async {
     try {

--- a/lib/features/mypage/mentor_time_setting/mentor_time_setting_screen.dart
+++ b/lib/features/mypage/mentor_time_setting/mentor_time_setting_screen.dart
@@ -32,7 +32,6 @@ class _MentorTimeSettingScreenState extends State<MentorTimeSettingScreen> {
     );
     Future.microtask(() {
       viewModel.loadPossibleDatesFromApi();
-      viewModel.loadMentorIntroductionStatus();
     });
   }
 
@@ -138,11 +137,13 @@ class _MentorTimeSettingScreenState extends State<MentorTimeSettingScreen> {
                         child: BasicButton(
                           onPressed: () async {
                             await viewModel.putPossibleDates();
-                            context.push(Paths.timeChecking);
+                            context.push(Paths.timeChecking, extra: {
+                              'isIntroductionComplete':
+                                  viewModel.isIntroductionComplete,
+                            });
                           },
-                          text: viewModel.isMentorIntroductionComplete
-                              ? '저장하기'
-                              : '다음',
+                          text:
+                              viewModel.isIntroductionComplete ? '저장하기' : '다음',
                           isClickable: _isSelected,
                           size: BasicButtonSize.SMALL,
                         ),


### PR DESCRIPTION
## Issue

- Resolves #121

## Description
<!-- 어떤 기능을 구현했나요?    
기존 기능에서 어떤 점이 달라졌나요?  
자세한 로직이 필요하다면 함께 적어주세요!  
코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!   -->

### 멘토 자기소개 다이얼로그 구별 방식 변경
기존 로컬 값으로 멘토 자기소개 완료를 관리했는데 이를 토큰으로 멘토 자기소개 api를 통해 관리하는 방식으로 변경하였습니다.

### 멘토 롤로 멘토 자기소개 미등록시 코고 탭 진입 불가

기존에도 추가했던 기능인데 코드 수정으로 기능하지 않았던 부분으로 이번에 멘토 자기소개 다이얼로그 구별 방식을 변경하하면서 오류를 수정하였습니다.

## Screenshot
<!--기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요  -->

## 💬 리뷰 요구사항(선택)
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 고민사항도 적어주세요.  -->
