### PR TITLE
[Fix] 내비게이션 구조 개선, 앱 안정성 확보 및 UI/UX 고도화

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -12,7 +12,7 @@
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
-        android:label="COGO"
+        android:label="코고"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_logo">
         <activity

--- a/ios/Flutter/Profile.xcconfig
+++ b/ios/Flutter/Profile.xcconfig
@@ -1,3 +1,3 @@
-#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"
 #include "Generated.xcconfig"
 FRAMEWORK_SEARCH_PATHS = $(inherited) $(PODS_CONFIGURATION_BUILD_DIR)

--- a/ios/Flutter/Release.xcconfig
+++ b/ios/Flutter/Release.xcconfig
@@ -1,2 +1,3 @@
 #include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"
+FRAMEWORK_SEARCH_PATHS = $(inherited) $(PODS_CONFIGURATION_BUILD_DIR)

--- a/ios/Runner.xcodeproj/project.pbxproj
+++ b/ios/Runner.xcodeproj/project.pbxproj
@@ -52,6 +52,7 @@
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
+		B7C8675BBEC94BF5B08FADCD /* Profile.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Profile.xcconfig; path = Flutter/Profile.xcconfig; sourceTree = "<group>"; };
 		7DEED30E0A36AAC288149D5F /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
@@ -110,6 +111,7 @@
 				3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */,
 				9740EEB21CF90195004384FC /* Debug.xcconfig */,
 				7AFA3C8E1D35360C0083082E /* Release.xcconfig */,
+				B7C8675BBEC94BF5B08FADCD /* Profile.xcconfig */,
 				9740EEB31CF90195004384FC /* Generated.xcconfig */,
 			);
 			name = Flutter;
@@ -460,7 +462,7 @@
 		};
 		249021D4217E4FDB00AE95B9 /* Profile */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 7AFA3C8E1D35360C0083082E /* Release.xcconfig */;
+			baseConfigurationReference = B7C8675BBEC94BF5B08FADCD /* Profile.xcconfig */;
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CLANG_ENABLE_MODULES = YES;

--- a/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -14,6 +14,20 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8B74B458B450D74B75744B87BD747314"
+               BuildableName = "Pods_Runner.framework"
+               BlueprintName = "Pods-Runner"
+               ReferencedContainer = "container:Pods/Pods.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
                BlueprintIdentifier = "97C146ED1CF9000F007C117D"
                BuildableName = "Runner.app"
                BlueprintName = "Runner"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -14,7 +14,7 @@
    <key>CFBundleDevelopmentRegion</key>
    <string>$(DEVELOPMENT_LANGUAGE)</string>
    <key>CFBundleDisplayName</key>
-   <string>Cogo Dev App</string>
+   <string>코고</string>
    <key>CFBundleExecutable</key>
    <string>$(EXECUTABLE_NAME)</string>
    <key>CFBundleIdentifier</key>
@@ -22,7 +22,7 @@
    <key>CFBundleInfoDictionaryVersion</key>
    <string>6.0</string>
    <key>CFBundleName</key>
-   <string>COGO</string>
+   <string>코고</string>
    <key>CFBundlePackageType</key>
    <string>APPL</string>
    <key>CFBundleShortVersionString</key>

--- a/lib/common/navigator/bottom_navigation_bar.dart
+++ b/lib/common/navigator/bottom_navigation_bar.dart
@@ -44,7 +44,7 @@ class ScaffoldWithNestedNavigation extends StatelessWidget {
                     showSelectedLabels: true,
                     showUnselectedLabels: true,
                     currentIndex: navigationShell.currentIndex,
-                    onTap: (index) => controller.setIndex(index, context),
+                    onTap: (index) => controller.setIndex(index, context, navigationShell),
                     backgroundColor: Colors.transparent,
                     selectedItemColor: Colors.white,
                     unselectedItemColor: const Color(0xFF626262),

--- a/lib/common/navigator/bottom_navigation_bar_view_model.dart
+++ b/lib/common/navigator/bottom_navigation_bar_view_model.dart
@@ -58,9 +58,10 @@ class BottomNavigationViewModel extends ChangeNotifier {
     notifyListeners();
     navigationShell.goBranch(index);
 
-    // 다음 frame 완료 후 가드 해제
+    // 다음 frame 완료 후 가드 해제 + 탭 진입 시 새로고침
     WidgetsBinding.instance.addPostFrameCallback((_) {
       _isSwitching = false;
+      _refreshTab(index, context);
     });
   }
 

--- a/lib/common/navigator/bottom_navigation_bar_view_model.dart
+++ b/lib/common/navigator/bottom_navigation_bar_view_model.dart
@@ -21,6 +21,9 @@ class BottomNavigationViewModel extends ChangeNotifier {
 
   bool shouldShowDialog = false;
 
+  // 연속 탭 방지 플래그 — goBranch() 후 다음 frame 완료 전까지 추가 전환 차단
+  bool _isSwitching = false;
+
   BottomNavigationViewModel(this.goRouter);
 
   void initialize(BuildContext context) {
@@ -37,32 +40,28 @@ class BottomNavigationViewModel extends ChangeNotifier {
     notifyListeners();
   }
 
-  void setIndex(int index, BuildContext context) {
+  void setIndex(int index, BuildContext context, StatefulNavigationShell navigationShell) {
     if (index == 1 && role == Role.ROLE_MENTOR.name && shouldShowDialog) {
       _showMentorProfileDialog(context);
       return;
     }
-    if (_selectedIndex == index) {
+    // 같은 탭 재탭: 새로고침
+    if (navigationShell.currentIndex == index) {
       _refreshTab(index, context);
-    } else {
-      _selectedIndex = index;
-      notifyListeners(); // 인덱스 변경 알림
-
-      switch (index) {
-        case 0:
-          context.go('/home');
-          break;
-        case 1:
-          context.go('/cogo');
-          break;
-        case 2:
-          context.go('/chat');
-          break;
-        case 3:
-          context.go('/mypage');
-          break;
-      }
+      return;
     }
+    // 전환 중에는 추가 goBranch 호출 차단 (rapid-tap → duplicate key 방지)
+    if (_isSwitching) return;
+    _isSwitching = true;
+
+    _selectedIndex = index;
+    notifyListeners();
+    navigationShell.goBranch(index);
+
+    // 다음 frame 완료 후 가드 해제
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      _isSwitching = false;
+    });
   }
 
   /// 각 탭의 ViewModel을 찾아 데이터를 새로고침하는 함수
@@ -94,7 +93,7 @@ class BottomNavigationViewModel extends ChangeNotifier {
         buttonText: "멘토 프로필 작성하기",
         onPressed: () {
           Navigator.of(context).pop();
-          Future.microtask(() => context.push(Paths.mentorIntroduction));
+          Future.microtask(() => context.safePush(Paths.mentorIntroduction));
         },
       ),
     );

--- a/lib/common/utils/navigation_guard.dart
+++ b/lib/common/utils/navigation_guard.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/scheduler.dart';
+import 'package:flutter/widgets.dart';
+import 'package:go_router/go_router.dart';
+
+// 전역 플래그 — push 후 다음 frame 완료 전까지 추가 push 차단
+bool _isNavigating = false;
+
+/// context.push를 대체하는 안전 버전.
+/// 동일 frame 내 중복 push → Navigator duplicate key assertion 방지.
+///
+/// 사용법:
+///   기존: context.push(path)
+///   변경: context.safePush(path)
+extension SafeNavigationExtension on BuildContext {
+  Future<T?> safePush<T extends Object?>(
+    String location, {
+    Object? extra,
+  }) {
+    if (_isNavigating) return Future.value(null);
+    _isNavigating = true;
+    final result = GoRouter.of(this).push<T>(location, extra: extra);
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _isNavigating = false;
+    });
+    return result;
+  }
+}
+
+/// ViewModel 등 BuildContext 없이 사용할 때의 헬퍼 (기존 호환용)
+class NavigationGuard {
+  NavigationGuard._();
+
+  static void run(void Function() navigate) {
+    if (_isNavigating) return;
+    _isNavigating = true;
+    navigate();
+    SchedulerBinding.instance.addPostFrameCallback((_) {
+      _isNavigating = false;
+    });
+  }
+}

--- a/lib/common/utils/routing_extension.dart
+++ b/lib/common/utils/routing_extension.dart
@@ -1,7 +1,10 @@
 import 'dart:developer';
 
+import 'package:cogo/common/utils/navigation_guard.dart';
 import 'package:flutter/material.dart';
 import 'package:go_router/go_router.dart';
+
+export 'package:cogo/common/utils/navigation_guard.dart';
 
 extension RoutingExtension on BuildContext {
   void popUntil(String path) {

--- a/lib/common/widgets/profile_card.dart
+++ b/lib/common/widgets/profile_card.dart
@@ -90,27 +90,35 @@ class ProfileCard extends StatelessWidget {
                 ),
               ],
             ),
-            Padding(
-              padding: const EdgeInsets.all(16.0),
-              child: Column(
-                crossAxisAlignment: CrossAxisAlignment.start,
-                children: [
-                  const SizedBox(height: 8),
-                  Text(
-                    showMentorSuffix ? '$mentorName 멘토님' : mentorName,
-                    style: CogoTextStyle.body20,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    title,
-                    style: CogoTextStyle.body14,
-                  ),
-                  const SizedBox(height: 8),
-                  Text(
-                    description,
-                    style: CogoTextStyle.body12.copyWith(color: CogoColor.systemGray03),
-                  ),
-                ],
+            Expanded(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const SizedBox(height: 4),
+                    Text(
+                      showMentorSuffix ? '$mentorName 멘토님' : mentorName,
+                      style: CogoTextStyle.body20,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      title,
+                      style: CogoTextStyle.body14,
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      description,
+                      style: CogoTextStyle.body12.copyWith(color: CogoColor.systemGray03),
+                      maxLines: 2,
+                      overflow: TextOverflow.ellipsis,
+                    ),
+                  ],
+                ),
               ),
             ),
           ],

--- a/lib/constants/constants.dart
+++ b/lib/constants/constants.dart
@@ -1,3 +1,4 @@
 export 'apis.dart';
 export 'colors.dart';
 export 'paths.dart';
+export '../common/utils/navigation_guard.dart';

--- a/lib/constants/paths.dart
+++ b/lib/constants/paths.dart
@@ -1,3 +1,5 @@
+export '../common/utils/navigation_guard.dart';
+
 abstract class Paths {
   Paths._();
 

--- a/lib/data/di/api_client.dart
+++ b/lib/data/di/api_client.dart
@@ -37,7 +37,7 @@ class ApiClient {
 
           if (token != null) {
             options.headers['Authorization'] = 'Bearer $token';
-            debugPrint('[Interceptor] Authorization header 설정됨 (token 앞 20자: ${token.length > 20 ? token.substring(0, 20) : token}...)');
+            debugPrint('[Interceptor] Authorization header 설정됨 (token: $token)');
           } else {
             debugPrint('[Interceptor] 토큰 없음 (skip=$skip), path=${options.path}');
           }

--- a/lib/features/auth/login/login_screen.dart
+++ b/lib/features/auth/login/login_screen.dart
@@ -1,6 +1,8 @@
 import 'package:cogo/common/enums/login_platform.dart';
 import 'package:cogo/common/enums/account_status.dart';
 import 'package:cogo/constants/paths.dart';
+import 'package:cogo/features/cogo/cogo_view_model.dart';
+import 'package:cogo/features/home/home_view_model.dart';
 import 'package:flutter/foundation.dart'
     show kIsWeb, defaultTargetPlatform, TargetPlatform;
 import 'package:flutter/material.dart';
@@ -55,6 +57,7 @@ class LoginScreen extends StatelessWidget {
                       platform: LoginPlatform.google,
                       onTap: () async {
                         await viewModel.signInWithGoogle();
+                        if (!context.mounted) return;
                         if (viewModel.loginStatus ==
                             AccountStatus.NEW_ACCOUNT.name) {
                           context.push(Paths.agreement);
@@ -62,6 +65,7 @@ class LoginScreen extends StatelessWidget {
                                 AccountStatus.EXISTING_ACCOUNT.name ||
                             viewModel.loginStatus ==
                                 AccountStatus.RESTORED_ACCOUNT.name) {
+                          _refreshViewModelsOnLogin(context);
                           context.push(Paths.home);
                         }
                       },
@@ -76,12 +80,14 @@ class LoginScreen extends StatelessWidget {
                         platform: LoginPlatform.apple,
                         onTap: () async {
                           await viewModel.signInWithApple();
+                          if (!context.mounted) return;
                           if (viewModel.loginStatus ==
                                   AccountStatus.NEW_ACCOUNT.name ||
                               viewModel.loginStatus ==
                                   AccountStatus.RESTORED_ACCOUNT.name) {
                             context.push(Paths.agreement);
                           } else {
+                            _refreshViewModelsOnLogin(context);
                             context.push(Paths.home);
                           }
                         },
@@ -188,6 +194,12 @@ class LoginScreen extends StatelessWidget {
   //     },
   //   );
   // }
+
+  /// 로그인 성공 시 전역 ViewModel을 서버 최신 데이터로 갱신
+  void _refreshViewModelsOnLogin(BuildContext context) {
+    context.read<CogoViewModel>().refreshCogo();
+    context.read<HomeViewModel>().refreshHome();
+  }
 
   Widget _loginButton({
     required LoginPlatform platform,

--- a/lib/features/auth/login/login_screen.dart
+++ b/lib/features/auth/login/login_screen.dart
@@ -60,13 +60,13 @@ class LoginScreen extends StatelessWidget {
                         if (!context.mounted) return;
                         if (viewModel.loginStatus ==
                             AccountStatus.NEW_ACCOUNT.name) {
-                          context.push(Paths.agreement);
+                          context.safePush(Paths.agreement);
                         } else if (viewModel.loginStatus ==
                                 AccountStatus.EXISTING_ACCOUNT.name ||
                             viewModel.loginStatus ==
                                 AccountStatus.RESTORED_ACCOUNT.name) {
                           _refreshViewModelsOnLogin(context);
-                          context.push(Paths.home);
+                          context.go(Paths.home);
                         }
                       },
                     ),
@@ -85,10 +85,10 @@ class LoginScreen extends StatelessWidget {
                                   AccountStatus.NEW_ACCOUNT.name ||
                               viewModel.loginStatus ==
                                   AccountStatus.RESTORED_ACCOUNT.name) {
-                            context.push(Paths.agreement);
+                            context.safePush(Paths.agreement);
                           } else {
                             _refreshViewModelsOnLogin(context);
-                            context.push(Paths.home);
+                            context.go(Paths.home);
                           }
                         },
                       ),
@@ -176,7 +176,7 @@ class LoginScreen extends StatelessWidget {
   //               if (isValid) {
   //                 // 로그인 성공 시 홈으로 이동
   //                 if (context.mounted) {
-  //                   context.push(Paths.home);
+  //                   context.safePush(Paths.home);
   //                 }
   //               } else {
   //                 // 로그인 실패 시 에러 메시지

--- a/lib/features/auth/signup/agreement/terms_bottom_sheet.dart
+++ b/lib/features/auth/signup/agreement/terms_bottom_sheet.dart
@@ -153,7 +153,7 @@ class _TermsBottomSheetState extends State<TermsBottomSheet> {
     return InkWell(
       onTap: () {
         if (term.route != null) {
-          context.push(term.route!);
+          context.safePush(term.route!);
         } else {
           setState(() {
             term.agreed = !term.agreed;
@@ -204,6 +204,6 @@ class _TermsBottomSheetState extends State<TermsBottomSheet> {
 
   /// "시작하기" 버튼 눌렀을 때 (필수 약관 체크 여부 확인)
   void _onStartPressed() {
-    context.push('${Paths.agreement}/${Paths.phone}');
+    context.safePush('${Paths.agreement}/${Paths.phone}');
   }
 }

--- a/lib/features/auth/signup/choose_role/choose_role_screen.dart
+++ b/lib/features/auth/signup/choose_role/choose_role_screen.dart
@@ -49,7 +49,7 @@ class ChooseRoleScreen extends StatelessWidget {
                                     // 비동기 작업 후 context가 유효한지 확인 (안전장치)
                                     if (!context.mounted) return;
 
-                                    context.push('${Paths.agreement}/${Paths.interest}');
+                                    context.safePush('${Paths.agreement}/${Paths.interest}');
                                   },
                                 ),
                               ),
@@ -62,7 +62,7 @@ class ChooseRoleScreen extends StatelessWidget {
 
                                     if (!context.mounted) return;
 
-                                    context.push('${Paths.agreement}/${Paths.interest}');
+                                    context.safePush('${Paths.agreement}/${Paths.interest}');
                                   },
                                 ),
                               ),

--- a/lib/features/auth/signup/club/club_selection_screen.dart
+++ b/lib/features/auth/signup/club/club_selection_screen.dart
@@ -48,7 +48,7 @@ class ClubSelectionScreen extends StatelessWidget {
                                       onPressed: () {
                                         viewModel.selectClub('GDGoC');
 
-                                        context.push(
+                                        context.safePush(
                                             '${Paths.agreement}/${Paths.mentorInfo}');
                                       },
                                     ),
@@ -59,7 +59,7 @@ class ClubSelectionScreen extends StatelessWidget {
                                       text: 'YOURSSU',
                                       onPressed: () {
                                         viewModel.selectClub('YOURSSU');
-                                        context.push(
+                                        context.safePush(
                                             '${Paths.agreement}/${Paths.mentorInfo}');
                                       },
                                     ),
@@ -76,7 +76,7 @@ class ClubSelectionScreen extends StatelessWidget {
                                       text: 'UMC',
                                       onPressed: () {
                                         viewModel.selectClub('UMC');
-                                        context.push(
+                                        context.safePush(
                                             '${Paths.agreement}/${Paths.mentorInfo}');
                                       },
                                     ),
@@ -87,7 +87,7 @@ class ClubSelectionScreen extends StatelessWidget {
                                       text: 'LIKELION',
                                       onPressed: () {
                                         viewModel.selectClub('LIKELION');
-                                        context.push(
+                                        context.safePush(
                                             '${Paths.agreement}/${Paths.mentorInfo}');
                                       },
                                     ),
@@ -102,7 +102,7 @@ class ClubSelectionScreen extends StatelessWidget {
                                       text: 'NO CLUB',
                                       onPressed: () {
                                         viewModel.selectClub('NO CLUB');
-                                        context.push(
+                                        context.safePush(
                                             '${Paths.agreement}/${Paths.mentorInfo}');
                                       },
                                       size: SBSize.LARGE,

--- a/lib/features/auth/signup/interest/interest_selection_screen.dart
+++ b/lib/features/auth/signup/interest/interest_selection_screen.dart
@@ -99,7 +99,7 @@ class InterestSelectionScreen extends StatelessWidget {
     // 2. 역할에 따른 분기
     if (viewModel.role == Role.ROLE_MENTOR.name) {
       // 멘토: 즉시 이동
-      context.push('${Paths.agreement}/${Paths.mentorClub}');
+      context.safePush('${Paths.agreement}/${Paths.mentorClub}');
     } else {
       // 멘티: 회원가입 API 호출 후 성공 시 이동
       final bool isSuccess = await viewModel.signUpMentee(interest);
@@ -107,7 +107,7 @@ class InterestSelectionScreen extends StatelessWidget {
       if (!context.mounted) return;
 
       if (isSuccess) {
-        context.push('${Paths.agreement}/${Paths.completion}');
+        context.safePush('${Paths.agreement}/${Paths.completion}');
       } else {
         // 실패 시 사용자에게 알림
         ScaffoldMessenger.of(context).showSnackBar(

--- a/lib/features/auth/signup/mentor_info/mentor_info_screen.dart
+++ b/lib/features/auth/signup/mentor_info/mentor_info_screen.dart
@@ -81,7 +81,7 @@ class MentorInfoScreen extends StatelessWidget {
 
                                     if (isSuccessful) {
                                       if (context.mounted) {
-                                        context.push(
+                                        context.safePush(
                                             '${Paths.agreement}/${Paths.completion}');
                                       }
                                     } else {

--- a/lib/features/auth/signup/name_input/name_input_screen.dart
+++ b/lib/features/auth/signup/name_input/name_input_screen.dart
@@ -85,7 +85,7 @@ class NameInputScreen extends StatelessWidget {
                                                 .setPhoneNumber(phoneNumber!);
                                             viewModel.onConfirmButtonPressed();
 
-                                            context.push(
+                                            context.safePush(
                                                 '${Paths.agreement}/${Paths.choose}');
                                           }
                                         : null,

--- a/lib/features/auth/signup/phone_number/phone_number_view_model.dart
+++ b/lib/features/auth/signup/phone_number/phone_number_view_model.dart
@@ -85,7 +85,7 @@ class PhoneNumberViewModel extends ChangeNotifier {
       if (_verificationCode?.toString() == codeController.text) {
         TextInput.finishAutofillContext();
 
-        context.push("${Paths.agreement}/${Paths.name}",
+        context.safePush("${Paths.agreement}/${Paths.name}",
             extra: phoneController.text);
       } else {
         errorMessage.value = '인증번호가 일치하지 않습니다.';

--- a/lib/features/chat/chat_sreean.dart
+++ b/lib/features/chat/chat_sreean.dart
@@ -142,7 +142,7 @@ class _ChatRoomTile extends StatelessWidget {
 
     return ListTile(
       onTap: () async {
-        await context.push(Paths.chattingRoom, extra: room);
+        await context.safePush(Paths.chattingRoom, extra: room);
         if (context.mounted) {
           context.read<ChatViewModel>().refreshChatRooms();
         }

--- a/lib/features/chat/chatting_room/chatting_room_screen.dart
+++ b/lib/features/chat/chatting_room/chatting_room_screen.dart
@@ -81,9 +81,9 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
 
       // canIssue == true
       if (viewModel.role == Role.ROLE_MENTOR.name) {
-        context.push(Paths.qr, extra: applicationId);
+        context.safePush(Paths.qr, extra: applicationId);
       } else {
-        context.push(Paths.qrScanner, extra: applicationId);
+        context.safePush(Paths.qrScanner, extra: applicationId);
       }
     } catch (e) {
       if (!mounted) return;

--- a/lib/features/chat/chatting_room/chatting_room_screen.dart
+++ b/lib/features/chat/chatting_room/chatting_room_screen.dart
@@ -229,14 +229,24 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
       );
     }
     return Expanded(
-      child: GestureDetector(
-        onTap: () {
-          _closePanel();
-          FocusScope.of(context).unfocus();
-        },
+      child: Listener(
         behavior: HitTestBehavior.translucent,
-        child: ListView.builder(
-          controller: _scrollController,
+        onPointerMove: (event) {
+          // 아래 방향 드래그 시 키보드 내리기 (스크롤 불가 상황에서도 동작)
+          if (event.delta.dy > 0) {
+            _closePanel();
+            FocusScope.of(context).unfocus();
+          }
+        },
+        child: GestureDetector(
+          onTap: () {
+            _closePanel();
+            FocusScope.of(context).unfocus();
+          },
+          behavior: HitTestBehavior.translucent,
+          child: ListView.builder(
+            controller: _scrollController,
+            keyboardDismissBehavior: ScrollViewKeyboardDismissBehavior.onDrag,
           padding: const EdgeInsets.symmetric(horizontal: 10, vertical: 16),
           itemCount: viewModel.messages.length + 1,
           itemBuilder: (context, index) {
@@ -276,6 +286,7 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
               ],
             );
           },
+        ),
         ),
       ),
     );

--- a/lib/features/chat/chatting_room/chatting_room_screen.dart
+++ b/lib/features/chat/chatting_room/chatting_room_screen.dart
@@ -230,7 +230,10 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
     }
     return Expanded(
       child: GestureDetector(
-        onTap: _closePanel,
+        onTap: () {
+          _closePanel();
+          FocusScope.of(context).unfocus();
+        },
         behavior: HitTestBehavior.translucent,
         child: ListView.builder(
           controller: _scrollController,

--- a/lib/features/chat/chatting_room/chatting_room_view_model.dart
+++ b/lib/features/chat/chatting_room/chatting_room_view_model.dart
@@ -197,7 +197,7 @@ class ChattingRoomViewModel extends ChangeNotifier {
   }
 
   void report(BuildContext context){
-    context.push(
+    context.safePush(
       Paths.report,
       extra: {
         'reporterId': myId,

--- a/lib/features/chat/chatting_room/widgets/cogo_schedule_header.dart
+++ b/lib/features/chat/chatting_room/widgets/cogo_schedule_header.dart
@@ -41,7 +41,7 @@ class CogoScheduleHeader extends StatelessWidget {
               ),
               GestureDetector(
                 onTap: () {
-                  context.push(
+                  context.safePush(
                     Paths.matchedCogoDetail,
                     extra: {
                       'applicationId': viewModel.applicationId,

--- a/lib/features/cogo/cogo_screen.dart
+++ b/lib/features/cogo/cogo_screen.dart
@@ -11,67 +11,64 @@ class CogoScreen extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ChangeNotifierProvider(
-      create: (_) => CogoViewModel(),
-      child: Scaffold(
-        backgroundColor: Colors.white,
-        body: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.only(top: 50.0),
-            child: Consumer<CogoViewModel>(
-              builder: (context, viewModel, child) {
-                return Column(
-                  crossAxisAlignment: CrossAxisAlignment.start,
-                  children: [
-                    const Padding(
-                      padding: EdgeInsets.only(left: 15.0),
-                      child: Text(
-                        '내 코고함',
-                        style: CogoTextStyle.body18,
-                      ),
+    return Scaffold(
+      backgroundColor: Colors.white,
+      body: SafeArea(
+        child: Padding(
+          padding: const EdgeInsets.only(top: 50.0),
+          child: Consumer<CogoViewModel>(
+            builder: (context, viewModel, child) {
+              return Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  const Padding(
+                    padding: EdgeInsets.only(left: 15.0),
+                    child: Text(
+                      '내 코고함',
+                      style: CogoTextStyle.body18,
                     ),
-                    Padding(
-                      padding: const EdgeInsets.symmetric(horizontal: 16.0),
-                      child: Text(
-                        'COGO를 하면서 많은 성장을 기원해요!',
-                        style: CogoTextStyle.body12
-                            .copyWith(color: CogoColor.systemGray03),
-                      ),
+                  ),
+                  Padding(
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0),
+                    child: Text(
+                      'COGO를 하면서 많은 성장을 기원해요!',
+                      style: CogoTextStyle.body12
+                          .copyWith(color: CogoColor.systemGray03),
                     ),
-                    const SizedBox(height: 20),
-                    Column(
-                      children: [
-                        ListTile(
-                          title: Text(
-                            viewModel.role == Role.ROLE_MENTOR.name
-                                ? '받은 코고'
-                                : '보낸 코고',
-                            style: CogoTextStyle.body16,
-                          ),
-                          trailing: const Icon(Icons.chevron_right),
-                          onTap: () {
-                            viewModel.navigateToReceivedCogo(context);
-                          },
+                  ),
+                  const SizedBox(height: 20),
+                  Column(
+                    children: [
+                      ListTile(
+                        title: Text(
+                          viewModel.role == Role.ROLE_MENTOR.name
+                              ? '받은 코고'
+                              : '보낸 코고',
+                          style: CogoTextStyle.body16,
                         ),
-                        const SizedBox(height: 5),
-                        const Divider(height: 0.2, color: Color(0xFFEDEDED)),
-                        const SizedBox(height: 5),
-                        ListTile(
-                          title: const Text(
-                            '응답된 코고',
-                            style: CogoTextStyle.body16,
-                          ),
-                          trailing: const Icon(Icons.chevron_right),
-                          onTap: () {
-                            viewModel.navigateToSuccessedCogo(context);
-                          },
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () {
+                          viewModel.navigateToReceivedCogo(context);
+                        },
+                      ),
+                      const SizedBox(height: 5),
+                      const Divider(height: 0.2, color: Color(0xFFEDEDED)),
+                      const SizedBox(height: 5),
+                      ListTile(
+                        title: const Text(
+                          '응답된 코고',
+                          style: CogoTextStyle.body16,
                         ),
-                      ],
-                    ),
-                  ],
-                );
-              },
-            ),
+                        trailing: const Icon(Icons.chevron_right),
+                        onTap: () {
+                          viewModel.navigateToSuccessedCogo(context);
+                        },
+                      ),
+                    ],
+                  ),
+                ],
+              );
+            },
           ),
         ),
       ),

--- a/lib/features/cogo/cogo_view_model.dart
+++ b/lib/features/cogo/cogo_view_model.dart
@@ -50,10 +50,10 @@ class CogoViewModel extends ChangeNotifier {
   }
 
   void navigateToReceivedCogo(BuildContext context) {
-    context.push(Paths.unMatchedCogo);
+    context.safePush(Paths.unMatchedCogo);
   }
 
   void navigateToSuccessedCogo(BuildContext context) {
-    context.push(Paths.matchedCogo);
+    context.safePush(Paths.matchedCogo);
   }
 }

--- a/lib/features/cogo/cogo_view_model.dart
+++ b/lib/features/cogo/cogo_view_model.dart
@@ -2,11 +2,14 @@ import 'dart:developer';
 
 import 'package:cogo/constants/constants.dart';
 import 'package:cogo/data/repository/local/secure_storage_repository.dart';
+import 'package:cogo/data/service/user_service.dart';
 import 'package:flutter/material.dart';
+import 'package:get_it/get_it.dart';
 import 'package:go_router/go_router.dart';
 
 class CogoViewModel extends ChangeNotifier {
   final SecureStorageRepository _secureStorage = SecureStorageRepository();
+  final UserService _userService = GetIt.instance<UserService>();
 
   String? _role;
   String? get role => _role;
@@ -24,14 +27,26 @@ class CogoViewModel extends ChangeNotifier {
   Future<void> getRole() async {
     try {
       _role = await _secureStorage.readRole();
+      // 스토리지에 role 없으면 서버에서 직접 조회 (로그인 직후 등)
+      if (_role == null) {
+        final response = await _userService.getUserInfo();
+        _role = response.role;
+        if (_role != null) {
+          await _secureStorage.saveRole(_role);
+        }
+      }
       log("Current Role: $_role");
-
-      // [핵심] 데이터가 같더라도 notifyListeners()를 호출해야
-      // Consumer를 사용하는 UI가 Rebuild 됩니다.
       notifyListeners();
     } catch (e) {
       log('Error fetching role: $e');
+      notifyListeners();
     }
+  }
+
+  /// 로그아웃 시 인메모리 상태 초기화
+  void reset() {
+    _role = null;
+    notifyListeners();
   }
 
   void navigateToReceivedCogo(BuildContext context) {

--- a/lib/features/cogo/matched_cogo/matched_cogo_view_model.dart
+++ b/lib/features/cogo/matched_cogo/matched_cogo_view_model.dart
@@ -54,7 +54,7 @@ class MatchedCogoViewModel extends ChangeNotifier {
       return;
     }
 
-    context.push(
+    context.safePush(
       Paths.matchedCogoDetail,
       extra: {
         'applicationId': item.applicationId,

--- a/lib/features/home/apply/memo/memo_view_model.dart
+++ b/lib/features/home/apply/memo/memo_view_model.dart
@@ -38,6 +38,6 @@ class MemoViewModel extends ChangeNotifier {
       'possibleDateId': possibleDateId,
     };
 
-    context.push(Paths.matching, extra: extraData);
+    context.safePush(Paths.matching, extra: extraData);
   }
 }

--- a/lib/features/home/apply/schedule/schedule_view_model.dart
+++ b/lib/features/home/apply/schedule/schedule_view_model.dart
@@ -95,6 +95,6 @@ class ScheduleViewModel extends ChangeNotifier {
       'mentorId': mentorId,
     };
 
-    context.push(Paths.memo, extra: extraData);
+    context.safePush(Paths.memo, extra: extraData);
   }
 }

--- a/lib/features/home/home_screen.dart
+++ b/lib/features/home/home_screen.dart
@@ -90,7 +90,7 @@ class _HomeScreenState extends State<HomeScreen>
             buttonText: "멘토 프로필 작성하기",
             onPressed: () {
               Navigator.of(context).pop();
-              Future.microtask(() => context.push(Paths.mentorIntroduction));
+              Future.microtask(() => context.safePush(Paths.mentorIntroduction));
             },
           ),
         );

--- a/lib/features/home/home_view_model.dart
+++ b/lib/features/home/home_view_model.dart
@@ -1,6 +1,7 @@
 import 'dart:developer';
 import 'package:cogo/common/enums/interest.dart';
 import 'package:cogo/common/enums/role.dart';
+import 'package:cogo/common/utils/navigation_guard.dart';
 import 'package:cogo/constants/paths.dart';
 import 'package:cogo/data/repository/local/secure_storage_repository.dart';
 import 'package:cogo/data/service/coupon_service.dart';
@@ -160,11 +161,11 @@ class HomeViewModel extends ChangeNotifier {
   }
 
   void onProfileCardTapped(BuildContext context, String mentorId) {
-    context.push('${Paths.profileDetail}?mentorId=$mentorId');
+    context.safePush('${Paths.profileDetail}?mentorId=$mentorId');
   }
 
   void onSearchPressed(BuildContext context) {
-    context.push(Paths.search);
+    context.safePush(Paths.search);
   }
 
 }

--- a/lib/features/home/home_view_model.dart
+++ b/lib/features/home/home_view_model.dart
@@ -86,6 +86,16 @@ class HomeViewModel extends ChangeNotifier {
     }
   }
 
+  /// 로그아웃 시 인메모리 상태 초기화
+  void reset() {
+    role = null;
+    profiles = null;
+    isInitialized = false;
+    isIntroductionComplete = null;
+    _shouldShowDialog = false;
+    notifyListeners();
+  }
+
   Future<void> refreshHome() async {
     // 1) 데이터를 null로 만들어 화면에 로딩 인디케이터가 뜨게 함 (시각적 리빌드 효과)
     profiles = null;

--- a/lib/features/home/mentor_detail/mentor_introduction_view_model.dart
+++ b/lib/features/home/mentor_detail/mentor_introduction_view_model.dart
@@ -87,7 +87,7 @@ class MentorIntroductionViewModel extends ChangeNotifier {
       await _mentorService.patchMentorIntroduction(
           title, description, answer1, answer2);
 
-      context.push(Paths.placeDetail);
+      context.safePush(Paths.placeDetail);
     } catch (e) {
       log('Failed to save introduction: $e');
     }

--- a/lib/features/home/mentor_detail/views/mentor_introduction_screen.dart
+++ b/lib/features/home/mentor_detail/views/mentor_introduction_screen.dart
@@ -67,7 +67,7 @@ class MentorIntroductionScreen extends StatelessWidget {
                         text: '다음',
                         isClickable: viewModel.isFormValid,
                         onPressed: viewModel.isFormValid
-                            ? () => context.push(Paths.mentorQuestion1)
+                            ? () => context.safePush(Paths.mentorQuestion1)
                             : null,
                       ),
                     );

--- a/lib/features/home/mentor_detail/views/mentor_introduction_screen.dart
+++ b/lib/features/home/mentor_detail/views/mentor_introduction_screen.dart
@@ -36,7 +36,7 @@ class MentorIntroductionScreen extends StatelessWidget {
                           children: [
                             BasicTextField(
                               controller: viewModel.titleController,
-                              hintText: '제목',
+                              hintText: '한 줄 소개',
                               currentCount: viewModel.tittleCharCount,
                               maxCount: 50,
                               size: BasicTextFieldSize.SMALL,
@@ -45,7 +45,7 @@ class MentorIntroductionScreen extends StatelessWidget {
                             const SizedBox(height: 10),
                             BasicTextField(
                               controller: viewModel.descriptionController,
-                              hintText: '내용을 입력해주세요',
+                              hintText: '간단하게 자기소개 부탁드려요',
                               currentCount: viewModel.descriptionCharCount,
                               maxCount: 200,
                               size: BasicTextFieldSize.LARGE,

--- a/lib/features/home/mentor_detail/views/mentor_question1_screen.dart
+++ b/lib/features/home/mentor_detail/views/mentor_question1_screen.dart
@@ -63,7 +63,7 @@ class MentorQuestion1Screen extends StatelessWidget {
                         text: '다음',
                         isClickable: viewModel.isFormValid,
                         onPressed: viewModel.isFormValid
-                            ? () => context.push(Paths.mentorQuestion2)
+                            ? () => context.safePush(Paths.mentorQuestion2)
                             : null,
                       ),
                     );

--- a/lib/features/home/mentor_detail/views/mentor_question1_screen.dart
+++ b/lib/features/home/mentor_detail/views/mentor_question1_screen.dart
@@ -35,7 +35,7 @@ class MentorQuestion1Screen extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             const Text(
-                              '멘토링 하실 분야에 대해 자세히 알려주세요',
+                              '이런 분야에서 멘토링이 가능해요',
                               style: CogoTextStyle.body16,
                             ),
                             const SizedBox(height: 10),

--- a/lib/features/home/mentor_detail/views/mentor_question2_screen.dart
+++ b/lib/features/home/mentor_detail/views/mentor_question2_screen.dart
@@ -33,7 +33,7 @@ class MentorQuestion2Screen extends StatelessWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             const Text(
-                              '프로젝트나 근무 경험이 있으시다면 알려주세요',
+                              '이런 경험들을 해왔어요',
                               style: CogoTextStyle.body16,
                             ),
                             const SizedBox(height: 10),

--- a/lib/features/home/place_detail_screen.dart
+++ b/lib/features/home/place_detail_screen.dart
@@ -57,11 +57,11 @@ class PlaceDetailScreen extends StatelessWidget {
                     text: '다음',
                     isClickable: true,
                     onPressed: () => mentorId != null
-                        ? context.push(
+                        ? context.safePush(
                             Paths.schedule,
                             extra: {'mentorId': mentorId},
                           )
-                        : context.push(Paths.timeSetting),
+                        : context.safePush(Paths.timeSetting),
                   ),
                 ),
               ),

--- a/lib/features/home/profile/profile_detail_view_model.dart
+++ b/lib/features/home/profile/profile_detail_view_model.dart
@@ -1,5 +1,6 @@
 import 'dart:developer';
 
+import 'package:cogo/common/utils/navigation_guard.dart';
 import 'package:cogo/data/repository/local/secure_storage_repository.dart';
 import 'package:cogo/domain/entity/mentor_detail_entity.dart';
 import 'package:flutter/material.dart';
@@ -47,19 +48,19 @@ class ProfileDetailViewModel extends ChangeNotifier {
   }
 
   void applyForCogo(BuildContext context, int mentorId) {
-    context.push(
+    context.safePush(
       Paths.placeDetail,
       extra: {'mentorId': mentorId},
     );
   }
 
-  void report(BuildContext context){
-    context.push(
+  void report(BuildContext context) {
+    context.safePush(
       Paths.report,
       extra: {
-      'reporterId': currentUserId,
-      'reportedUserId': reportedUserId,
-    },
+        'reporterId': currentUserId,
+        'reportedUserId': reportedUserId,
+      },
     );
   }
 }

--- a/lib/features/home/report/report_screen.dart
+++ b/lib/features/home/report/report_screen.dart
@@ -47,7 +47,7 @@ class ReportScreen extends StatelessWidget {
               ),
               trailing: const Icon(Icons.chevron_right),
               onTap: () {
-                context.push(
+                context.safePush(
                   Paths.reportDetail,
                   extra: {
                     'reason': reason,

--- a/lib/features/mypage/mentor_introduce/my_mentor_introduce_screen.dart
+++ b/lib/features/mypage/mentor_introduce/my_mentor_introduce_screen.dart
@@ -100,7 +100,7 @@ class MyMentorIntroductionScreen extends StatelessWidget {
                       const SizedBox(height: 30),
 
                       // 질문 1
-                      const Text('멘토링하실 분야에 대해 자세히 알려주세요',
+                      const Text('이런 분야에서 멘토링이 가능해요',
                           style: CogoTextStyle.body16),
                       const SizedBox(height: 10),
                       BasicTextField(
@@ -114,8 +114,7 @@ class MyMentorIntroductionScreen extends StatelessWidget {
                       const SizedBox(height: 30),
 
                       // 질문 2
-                      const Text('프로젝트나 근무 경험이 있으시다면 알려주세요',
-                          style: CogoTextStyle.body16),
+                      const Text('이런 경험들을 해왔어요', style: CogoTextStyle.body16),
                       const SizedBox(height: 10),
                       BasicTextField(
                         controller: viewModel.question2Controller,

--- a/lib/features/mypage/mentor_introduce/my_mentor_introduce_screen.dart
+++ b/lib/features/mypage/mentor_introduce/my_mentor_introduce_screen.dart
@@ -43,7 +43,7 @@ class MyMentorIntroductionScreen extends StatelessWidget {
                           BasicButton(
                             text: "로그인 화면으로 돌아가기",
                             isClickable: true,
-                            onPressed: () => context.push(Paths.login),
+                            onPressed: () => context.go(Paths.login),
                             size: BasicButtonSize.SMALL,
                           ),
                           const SizedBox(height: 10),

--- a/lib/features/mypage/mentor_time_checking/mentor_time_checking_screen.dart
+++ b/lib/features/mypage/mentor_time_checking/mentor_time_checking_screen.dart
@@ -81,7 +81,7 @@ class MentorTimeCheckingScreen extends StatelessWidget {
                               Navigator.of(context)
                                   .popUntil((route) => route.isFirst);
                             } else {
-                              context.push(Paths.mentorDetailCompletion);
+                              context.safePush(Paths.mentorDetailCompletion);
                             }
                           },
                           text: isIntroductionComplete ? '수정하기' : '완료',

--- a/lib/features/mypage/mentor_time_setting/mentor_time_setting_screen.dart
+++ b/lib/features/mypage/mentor_time_setting/mentor_time_setting_screen.dart
@@ -137,7 +137,7 @@ class _MentorTimeSettingScreenState extends State<MentorTimeSettingScreen> {
                         child: BasicButton(
                           onPressed: () async {
                             await viewModel.putPossibleDates();
-                            context.push(Paths.timeChecking, extra: {
+                            context.safePush(Paths.timeChecking, extra: {
                               'isIntroductionComplete':
                                   viewModel.isIntroductionComplete,
                             });

--- a/lib/features/mypage/mentor_time_setting/mentor_time_setting_view_model.dart
+++ b/lib/features/mypage/mentor_time_setting/mentor_time_setting_view_model.dart
@@ -151,6 +151,6 @@ class MentorTimeSettingViewModel extends ChangeNotifier {
   }
 
   void navigateToMentorTimeChecking(BuildContext context) {
-    context.push(Paths.timeChecking);
+    context.safePush(Paths.timeChecking);
   }
 }

--- a/lib/features/mypage/mypage_screen.dart
+++ b/lib/features/mypage/mypage_screen.dart
@@ -5,6 +5,8 @@ import 'package:cogo/common/widgets/tag_list.dart';
 import 'package:cogo/common/widgets/widgets.dart'; // BasicButton, TwoButtonDialog, CogoTextStyle 등
 import 'package:cogo/constants/constants.dart';
 import 'package:cogo/constants/paths.dart';
+import 'package:cogo/features/cogo/cogo_view_model.dart';
+import 'package:cogo/features/home/home_view_model.dart';
 import 'package:cogo/features/mypage/mypage_view_model.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
@@ -117,6 +119,9 @@ class MypageScreen extends StatelessWidget {
                         onTap: () async {
                           await viewModel.logOut();
                           if (context.mounted) {
+                            // 모든 전역 ViewModel 인메모리 상태 초기화
+                            context.read<CogoViewModel>().reset();
+                            context.read<HomeViewModel>().reset();
                             Future.microtask(() => context.go(Paths.login));
                           }
                         },

--- a/lib/features/mypage/mypage_screen.dart
+++ b/lib/features/mypage/mypage_screen.dart
@@ -46,7 +46,7 @@ class MypageScreen extends StatelessWidget {
                         text: "로그인 화면으로 돌아가기",
                         isClickable: true,
                         onPressed: () {
-                          context.push(Paths.login);
+                          context.go(Paths.login);
                         },
                         size: BasicButtonSize.SMALL,
                       ),
@@ -97,20 +97,20 @@ class MypageScreen extends StatelessWidget {
                         title:
                         const Text('내 정보 관리', style: CogoTextStyle.body16),
                         trailing: const Icon(Icons.chevron_right),
-                        onTap: () => context.push(Paths.myInfo),
+                        onTap: () => context.safePush(Paths.myInfo),
                       ),
                       if (user?.role == Role.ROLE_MENTOR.name) ...[
                         ListTile(
                           title: const Text('자기소개 관리',
                               style: CogoTextStyle.body16),
                           trailing: const Icon(Icons.chevron_right),
-                          onTap: () => context.push(Paths.myMentorIntroduce),
+                          onTap: () => context.safePush(Paths.myMentorIntroduce),
                         ),
                         ListTile(
                           title:
                           const Text('시간 설정', style: CogoTextStyle.body16),
                           trailing: const Icon(Icons.chevron_right),
-                          onTap: () => context.push(Paths.timeSetting),
+                          onTap: () => context.safePush(Paths.timeSetting),
                         ),
                       ],
                       ListTile(
@@ -152,7 +152,7 @@ class MypageScreen extends StatelessWidget {
     return GestureDetector(
       onTap: () async {
         // 이미지 수정 페이지로 이동
-        await context.push(Paths.image);
+        await context.safePush(Paths.image);
 
         // 돌아왔을 때 데이터 갱신 (사진 변경 반영)
         if (context.mounted) {

--- a/lib/features/mypage/mypage_screen.dart
+++ b/lib/features/mypage/mypage_screen.dart
@@ -193,20 +193,21 @@ class MypageScreen extends StatelessWidget {
             ),
           ),
 
-          // 2층: 카메라 아이콘 (항상 위에 표시)
-          Positioned.fill(
-            child: Align(
-              alignment: Alignment.center,
-              child: Container(
-                padding: const EdgeInsets.all(10),
-                child: const Icon(
-                  Icons.camera_alt,
-                  size: 40,
-                  color: CogoColor.systemGray03,
+          // 2층: 카메라 아이콘 (기본 이미지일 때만 표시)
+          if (!hasImage)
+            Positioned.fill(
+              child: Align(
+                alignment: Alignment.center,
+                child: Container(
+                  padding: const EdgeInsets.all(10),
+                  child: const Icon(
+                    Icons.camera_alt,
+                    size: 40,
+                    color: CogoColor.systemGray03,
+                  ),
                 ),
               ),
             ),
-          ),
         ],
       ),
     );

--- a/lib/features/splash_screen.dart
+++ b/lib/features/splash_screen.dart
@@ -26,11 +26,12 @@ class _SplashScreenState extends State<SplashScreen>
     final splashViewModel = GetIt.instance<SplashViewModel>(); // getIt 사용
     splashViewModel.autoLogin().then((isLoggedIn) {
       Future.delayed(const Duration(seconds: 2), () {
+        if (!mounted) return;
         if (isLoggedIn) {
           log("=====자동로그인 성공=====");
-          context.push(Paths.home);
+          context.go(Paths.home);
         } else {
-          context.push(Paths.login);
+          context.go(Paths.login);
         }
       });
     });

--- a/lib/route/routes.dart
+++ b/lib/route/routes.dart
@@ -389,10 +389,7 @@ StatefulShellBranch _createBranch(String path, Widget child) {
     routes: [
       GoRoute(
         path: path,
-        pageBuilder: (context, state) => MaterialPage(
-          key: state.pageKey,
-          child: child,
-        ),
+        builder: (context, state) => child,
       ),
     ],
   );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -3,7 +3,7 @@ description: "COGO"
 
 publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 
-version: 2.1.1+10
+version: 2.1.2+11
 
 environment:
   sdk: '>=3.4.3 <4.0.0'


### PR DESCRIPTION
## Issue

- Resolves #166 

## Description
<!-- 어떤 기능을 구현했나요?    
기존 기능에서 어떤 점이 달라졌나요?  
자세한 로직이 필요하다면 함께 적어주세요!  
코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!   -->

본 PR은 앱 전반의 내비게이션 로직을 정교화하고, 중복 호출 방지 및 상태 초기화 로직을 도입하여 앱의 안정성을 높이는 것을 목표로 합니다. 또한, 사용자 피드백을 반영하여 채팅방 키보드 동작 및 탭 전환 UX를 개선하였습니다.

### 🚀 주요 변경 사항
#### 1. 내비게이션 시스템 고도화 (GoRouter & Stability)
- 전역 Navigation Guard (safePush) 도입:
동일 프레임 내 중복 push 호출로 인한 에러를 방지하기 위해 SafeNavigationExtension 구현.
프로젝트 내 51개의 push 호출을 safePush로 일괄 전환하여 안정성 확보.
- 최상위 화면 전환 로직 수정:
/home, /login 등 스택 교체가 필요한 화면 전환 시 push 대신 go()를 사용하도록 수정하여 Shell Route의 비정상 동작 및 백버튼 문제를 해결.
- 중복 Key 에러 해결: bottom_navigation_bar_view_model에 _isSwitching 플래그를 도입하여 빠른 탭 전환 시 발생하는 Navigator duplicate key 에러를 차단.
- 탭 전환 애니메이션 제거: pageBuilder를 builder로 변경하여 탭 간 슬라이드 애니메이션을 제거하고, navigationShell.goBranch()를 사용하여 올바른 Shell 내비게이션을 수행하도록 개선.

#### 2. 상태 관리 및 데이터 동기화
- 로그아웃 시 데이터 초기화: CogoViewModel, HomeViewModel에 reset() 메서드를 추가하여 로그아웃 시 인메모리 상태(유저 역할, 프로필 등)를 명시적으로 초기화.
- 전역 Provider 전환: CogoViewModel을 로컬에서 전역(main.dart)으로 변경하여 StatefulShellRoute 캐싱 시에도 유저 역할(Role) 데이터가 유실되지 않도록 수정.
- Role 조회 Fallback 로직: SecureStorage에 데이터가 없을 경우 서버에서 직접 조회하도록 getRole() 로직 보완.

#### 3. UI/UX 개선
- 채팅방 키보드 제어:
배경 탭 시 키보드 닫기 및 드래그 시 키보드 닫기 기능 추가.
스크롤이 불가능한 짧은 채팅창에서도 Listener를 통해 아래로 슬라이드 시 키보드가 내려가도록 보완.
- 자동 새로고침: 탭 전환 시마다 addPostFrameCallback을 통해 해당 탭의 데이터를 최신화하도록 로직 변경.
- 조건부 UI: 마이페이지 프로필 설정 시, 이미지가 존재할 경우 카메라 아이콘이 보이지 않도록 분기 처리.

#### 4. 안정성 확보 (Bug Fix)
- Splash Screen 크래시 방지: Future.delayed 실행 전 mounted 체크를 추가하여 화면이 해제된 상태에서의 context 접근 차단.
- NavigationGuard 중복 래핑 수정: 일부 ViewModel에서 발생하던 이중 실행 버그 해결.

### 🛠️ 기술적 참고 사항
Safe Navigation: lib/common/utils/navigation_guard.dart에 정의된 Extension을 통해 전역적으로 관리됩니다.
Architecture: ViewModel 간의 책임 분리를 위해 reset()과 _refreshViewModelsOnLogin()을 적절히 배치하였습니다.


## Screenshot
<!--기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요  -->

## 💬 리뷰 요구사항(선택)
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 고민사항도 적어주세요.  -->
