### PR TITLE
[Feat] 채팅방 커서 기반 페이지네이션 및 스크롤 UX 개선

### DIFF
--- a/lib/data/dto/response/chat/cursor_chat_page_response.dart
+++ b/lib/data/dto/response/chat/cursor_chat_page_response.dart
@@ -1,0 +1,26 @@
+import 'package:cogo/data/dto/response/chat/chat_message_response.dart';
+
+class CursorChatPageResponse {
+  final List<ChatMessageResponse> content;
+  final String? nextCursorCreatedAt;
+  final int? nextCursorChatId;
+  final bool hasNext;
+
+  CursorChatPageResponse({
+    required this.content,
+    required this.nextCursorCreatedAt,
+    required this.nextCursorChatId,
+    required this.hasNext,
+  });
+
+  factory CursorChatPageResponse.fromJson(Map<String, dynamic> json) {
+    return CursorChatPageResponse(
+      content: (json['content'] as List<dynamic>)
+          .map((e) => ChatMessageResponse.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      nextCursorCreatedAt: json['nextCursorCreatedAt'] as String?,
+      nextCursorChatId: json['nextCursorChatId'] as int?,
+      hasNext: json['hasNext'] as bool,
+    );
+  }
+}

--- a/lib/data/service/chat_service.dart
+++ b/lib/data/service/chat_service.dart
@@ -1,8 +1,8 @@
 import 'package:cogo/constants/apis.dart';
 import 'package:cogo/data/di/api_client.dart';
-import 'package:cogo/data/dto/response/base_response.dart';
 import 'package:cogo/data/dto/response/chat/chat_message_response.dart';
 import 'package:cogo/data/dto/response/chat/chat_room_response.dart';
+import 'package:cogo/data/dto/response/chat/cursor_chat_page_response.dart';
 import 'package:cogo/data/dto/response/chat/linked_cogo_response.dart';
 import 'package:dio/dio.dart';
 
@@ -118,6 +118,45 @@ class ChatService {
     }
   }
 
+  /// 커서 기반 채팅 메시지 조회
+  /// 최초 호출: cursor 없이 size=50 → 최신 50개
+  /// 추가 로드: nextCursorCreatedAt, nextCursorChatId 전달 → 그 이전 50개
+  Future<CursorChatPageResponse> getCursorMessages({
+    required int roomId,
+    String? cursorCreatedAt,
+    int? cursorChatId,
+    int size = 50,
+  }) async {
+    try {
+      final queryParams = <String, dynamic>{'size': size};
+      if (cursorCreatedAt != null) {
+        queryParams['cursorCreatedAt'] = cursorCreatedAt;
+      }
+      if (cursorChatId != null) {
+        queryParams['cursorChatId'] = cursorChatId;
+      }
+
+      final response = await _apiClient.dio.get(
+        '${apiVersion}chat/rooms/$roomId/cursor/messages',
+        queryParameters: queryParams,
+        options: Options(extra: {'skipAuthToken': false}),
+      );
+
+      if (response.statusCode == 200) {
+        return CursorChatPageResponse.fromJson(
+            response.data as Map<String, dynamic>);
+      } else {
+        throw Exception(
+            'Failed to fetch messages: ${response.statusCode}');
+      }
+    } on DioException catch (e) {
+      _handleDioException(e);
+      throw Exception('Unreachable');
+    } catch (e) {
+      throw Exception('Unexpected error: $e');
+    }
+  }
+
   ///채팅방과 연결된 코고 조회
   Future<LinkedCogoResponse> getConnectedApplication(int chatRoomId) async {
     try {
@@ -158,6 +197,5 @@ class ChatService {
       default:
         throw Exception('Error: ${e.response?.statusCode} ${e.message}');
     }
-    throw Exception('Unreachable');
   }
 }

--- a/lib/features/chat/chatting_room/chatting_room_screen.dart
+++ b/lib/features/chat/chatting_room/chatting_room_screen.dart
@@ -11,7 +11,6 @@ import 'package:cogo/features/chat/chatting_room/widgets/attachment_panel.dart';
 import 'package:cogo/features/chat/chatting_room/widgets/chat_input_bar.dart';
 import 'package:cogo/features/chat/chatting_room/widgets/cogo_schedule_header.dart';
 import 'package:flutter/material.dart';
-import 'package:go_router/go_router.dart';
 import 'package:provider/provider.dart';
 import 'widgets/sender_message.dart';
 import 'widgets/receiver_message.dart';
@@ -36,6 +35,10 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
   late final AnimationController _panelController;
   bool _initialScrollDone = false;
 
+  // ── 이전 메시지 로드 ──────────────────────────────────────────
+  ChattingRoomViewModel? _viewModel;
+  bool _suppressScrollToBottom = false;
+
   static const double _panelHeight = 200.0;
 
   @override
@@ -46,6 +49,7 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
       duration: const Duration(milliseconds: 280),
     );
     WidgetsBinding.instance.addObserver(this);
+    _scrollController.addListener(_onScroll);
   }
 
   @override
@@ -126,9 +130,37 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
     });
   }
 
+  void _onScroll() {
+    if (!_scrollController.hasClients) return;
+    final position = _scrollController.position;
+    // 스크롤 가능한 콘텐츠가 없거나, 상단 200px 밖이면 무시
+    if (position.maxScrollExtent == 0) return;
+    if (position.pixels > 200) return;
+
+    final vm = _viewModel;
+    if (vm == null || !vm.hasNext || vm.isLoadingMore || _suppressScrollToBottom) return;
+
+    final oldMaxExtent = position.maxScrollExtent;
+    final oldPixels = position.pixels;
+
+    _suppressScrollToBottom = true;
+    vm.loadMoreMessages().then((_) {
+      WidgetsBinding.instance.addPostFrameCallback((_) {
+        if (!mounted || !_scrollController.hasClients) return;
+        final newMaxExtent = _scrollController.position.maxScrollExtent;
+        final delta = newMaxExtent - oldMaxExtent;
+        if (delta > 0) {
+          _scrollController.jumpTo(oldPixels + delta);
+        }
+        _suppressScrollToBottom = false;
+      });
+    });
+  }
+
   @override
   void dispose() {
     WidgetsBinding.instance.removeObserver(this);
+    _scrollController.removeListener(_onScroll);
     _controller.dispose();
     _scrollController.dispose();
     _panelController.dispose();
@@ -146,7 +178,8 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
             appBar: _buildAppBar(context),
             body: Consumer<ChattingRoomViewModel>(
               builder: (context, viewModel, _) {
-                _scrollToBottom();
+                _viewModel = viewModel;
+                if (!_suppressScrollToBottom) _scrollToBottom();
                 return Column(
                   children: [
                     CogoScheduleHeader(
@@ -198,7 +231,7 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
               Text(
                 widget.room.participants.first.isDeleted
                     ? '(알 수 없음)'
-                    : (widget.room.participants.first.name ?? ''),
+                    : widget.room.participants.first.name,
                 style: CogoTextStyle.bodySB20,
               ),
               const SizedBox(width: 5),
@@ -244,7 +277,19 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
       );
     }
     return Expanded(
-      child: Listener(
+      child: Column(
+        children: [
+          if (viewModel.isLoadingMore)
+            const Padding(
+              padding: EdgeInsets.symmetric(vertical: 6),
+              child: SizedBox(
+                width: 20,
+                height: 20,
+                child: CircularProgressIndicator(
+                    strokeWidth: 2, color: Colors.grey),
+              ),
+            ),
+          Expanded(child: Listener(
         behavior: HitTestBehavior.translucent,
         onPointerMove: (event) {
           // 아래 방향 드래그 시 키보드 내리기 (스크롤 불가 상황에서도 동작)
@@ -301,10 +346,13 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
               ],
             );
           },
-        ),
-        ),
-      ),
-    );
+        ),        // ListView.builder
+        ),        // GestureDetector
+        ),        // Listener
+        ),        // Expanded(child: Listener)
+        ],        // Column children
+      ),          // Column
+    );            // Expanded
   }
 
   Widget _buildNoticeItem() {

--- a/lib/features/chat/chatting_room/chatting_room_screen.dart
+++ b/lib/features/chat/chatting_room/chatting_room_screen.dart
@@ -38,6 +38,7 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
   // ── 이전 메시지 로드 ──────────────────────────────────────────
   ChattingRoomViewModel? _viewModel;
   bool _suppressScrollToBottom = false;
+  int _lastScrolledMessageCount = 0;
 
   static const double _panelHeight = 200.0;
 
@@ -152,6 +153,7 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
         if (delta > 0) {
           _scrollController.jumpTo(oldPixels + delta);
         }
+        _lastScrolledMessageCount = _viewModel?.messages.length ?? _lastScrolledMessageCount;
         _suppressScrollToBottom = false;
       });
     });
@@ -179,7 +181,13 @@ class _ChattingRoomScreenState extends State<ChattingRoomScreen>
             body: Consumer<ChattingRoomViewModel>(
               builder: (context, viewModel, _) {
                 _viewModel = viewModel;
-                if (!_suppressScrollToBottom) _scrollToBottom();
+                if (!_suppressScrollToBottom) {
+                  final count = viewModel.messages.length;
+                  if (count > _lastScrolledMessageCount) {
+                    _lastScrolledMessageCount = count;
+                    _scrollToBottom();
+                  }
+                }
                 return Column(
                   children: [
                     CogoScheduleHeader(

--- a/lib/features/chat/chatting_room/chatting_room_view_model.dart
+++ b/lib/features/chat/chatting_room/chatting_room_view_model.dart
@@ -6,8 +6,7 @@ import 'package:cogo/data/repository/local/secure_storage_repository.dart';
 import 'package:cogo/data/service/chat_service.dart';
 import 'package:cogo/data/service/stomp_service.dart';
 import 'package:cogo/main.dart' show activeChatRoomId;
-import 'package:flutter/material.dart'; // Cupertino보다 Material 권장 (ViewModel에서는 Foundation이나 Material)
-import 'package:go_router/go_router.dart';
+import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
 
 class ChattingRoomViewModel extends ChangeNotifier {
@@ -22,6 +21,7 @@ class ChattingRoomViewModel extends ChangeNotifier {
   // State Variables
   List<Message> messages = [];
   bool isLoading = false;
+  bool isLoadingMore = false;
 
   String? _role;
   String? get role => _role;
@@ -32,6 +32,13 @@ class ChattingRoomViewModel extends ChangeNotifier {
 
   int? myId;
   int? reportedUserId;
+  String? _profileUrl;
+
+  // 커서 페이지네이션
+  String? _nextCursorCreatedAt;
+  int? _nextCursorChatId;
+  bool _hasNext = false;
+  bool get hasNext => _hasNext;
 
   // ===========================================================================
   // 2. Constructor & Initialization
@@ -77,19 +84,17 @@ class ChattingRoomViewModel extends ChangeNotifier {
     }
   }
 
-  /// 채팅 메시지 로드 및 STOMP 연결
+  /// 채팅 메시지 로드 및 STOMP 연결 (커서 기반)
   Future<void> _loadChatting() async {
     try {
       int roomId = room.roomId;
-      String? profileUrl;
-
       myId = await _secureStorage.getUserId();
 
       if (room.participants.isNotEmpty && myId != null) {
         try {
           final otherParticipant = room.participants.firstWhere(
-                  (p) => p.userId != myId,
-              orElse: () => room.participants.first
+            (p) => p.userId != myId,
+            orElse: () => room.participants.first,
           );
           reportedUserId = otherParticipant.userId;
           log("상대방 ID(reportedUserId) 설정 완료: $reportedUserId");
@@ -99,27 +104,24 @@ class ChattingRoomViewModel extends ChangeNotifier {
       }
 
       if (room.participants.isNotEmpty) {
-        profileUrl = room.participants.first.profileImage;
+        _profileUrl = room.participants.first.profileImage;
       }
 
-      // 1. 이전 메시지 로드 (API)
-      final page = await _service.getChattingMessages(
-        roomId: roomId,
-        page: 0,
-        size: 100,
-      );
+      // 1. 커서 기반 최신 50개 로드
+      final result = await _service.getCursorMessages(roomId: roomId, size: 50);
 
-      messages = page.content.map((msg) {
-        return Message(
-          text: msg.message,
-          time: _formatTime(msg.createdAt),
-          createdAt: msg.createdAt,
-          isMe: msg.senderId == myId,
-          profileUrl: profileUrl,
-        );
-      }).toList();
-
+      messages = result.content.map((msg) => Message(
+        text: msg.message,
+        time: _formatTime(msg.createdAt),
+        createdAt: msg.createdAt,
+        isMe: msg.senderId == myId,
+        profileUrl: _profileUrl,
+      )).toList();
       messages.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+
+      _nextCursorCreatedAt = result.nextCursorCreatedAt;
+      _nextCursorChatId = result.nextCursorChatId;
+      _hasNext = result.hasNext;
 
       // 2. 실시간 소켓 연결 (STOMP)
       _stompService.connect(
@@ -127,28 +129,58 @@ class ChattingRoomViewModel extends ChangeNotifier {
         roomId: roomId,
         onMessage: (json) {
           final senderId = json['senderId'];
-
           final isMine = senderId.toString() == myId.toString();
-
-          if (isMine) {
-            return;
-          }
+          if (isMine) return;
 
           final now = DateTime.now();
-          messages.add(
-            Message(
-              text: json['message'],
-              time: _formatTime(now),
-              createdAt: now,
-              isMe: isMine,
-              profileUrl: profileUrl,
-            ),
-          );
+          messages.add(Message(
+            text: json['message'],
+            time: _formatTime(now),
+            createdAt: now,
+            isMe: isMine,
+            profileUrl: _profileUrl,
+          ));
           notifyListeners();
         },
       );
     } catch (e) {
       log('채팅 로드 실패: $e');
+    }
+  }
+
+  /// 이전 메시지 추가 로드 (스크롤 상단 도달 시 호출)
+  Future<void> loadMoreMessages() async {
+    if (!_hasNext || isLoadingMore) return;
+
+    isLoadingMore = true;
+    notifyListeners();
+
+    try {
+      final result = await _service.getCursorMessages(
+        roomId: room.roomId,
+        cursorCreatedAt: _nextCursorCreatedAt,
+        cursorChatId: _nextCursorChatId,
+        size: 50,
+      );
+
+      final olderMessages = result.content.map((msg) => Message(
+        text: msg.message,
+        time: _formatTime(msg.createdAt),
+        createdAt: msg.createdAt,
+        isMe: msg.senderId == myId,
+        profileUrl: _profileUrl,
+      )).toList();
+      olderMessages.sort((a, b) => a.createdAt.compareTo(b.createdAt));
+
+      messages = [...olderMessages, ...messages];
+      _nextCursorCreatedAt = result.nextCursorCreatedAt;
+      _nextCursorChatId = result.nextCursorChatId;
+      _hasNext = result.hasNext;
+    } catch (e) {
+      log('이전 메시지 로드 실패: $e');
+    } finally {
+      isLoadingMore = false;
+      notifyListeners();
     }
   }
 
@@ -169,10 +201,7 @@ class ChattingRoomViewModel extends ChangeNotifier {
     if (text.trim().isEmpty) return;
 
     // 1. 내 화면에 먼저 메시지 추가
-    final myId = await _secureStorage.getUserId();
     String? myProfileUrl;
-    if (room.participants.isNotEmpty) {}
-
     final now = DateTime.now();
     final newMessage = Message(
       text: text,
@@ -183,8 +212,6 @@ class ChattingRoomViewModel extends ChangeNotifier {
     );
     messages.add(newMessage);
     notifyListeners();
-
-    print('==== [전송 시도] 메시지: $text ====');
 
     // 2. 서버로 전송
     try {


### PR DESCRIPTION
## Issue

- Resolves #174 

## Description
<!-- 어떤 기능을 구현했나요?    
기존 기능에서 어떤 점이 달라졌나요?  
자세한 로직이 필요하다면 함께 적어주세요!  
코드에 대한 설명이라면, 코맨트를 통해서 어떤 부분이 어떤 코드인지 설명해주세요!   -->

  기존 채팅 메시지 조회는 page + size 방식으로 고정된 100개만 불러와 이전 메시지가 묻히는 문제가 있었습니다. 서버에서 커서 기반 API(/cursor/messages)를 제공해, 이를
  기반으로 전체 채팅 내역을 순차 조회할 수 있도록 클라이언트를 개선했습니다.

##  변경 사항
  
  ### 커서 기반 채팅 메시지 페이지네이션

  - CursorChatPageResponse DTO 신규 추가 (content, nextCursorCreatedAt, nextCursorChatId, hasNext)
  - ChatService.getCursorMessages() API 메서드 추가 (GET /api/v2/chat/rooms/{id}/cursor/messages)
  - 초기 진입 시 최신 50개 로드 → 상단 스크롤 시 이전 50개 추가 로드
  - ViewModel에 isLoadingMore, hasNext, 커서 상태 필드 추가 및 loadMoreMessages() 구현

  ### 타임존 버그 수정

  - 서버가 timezone 없는 문자열로 커서 시간을 반환하는데, DateTime으로 파싱 후 .toUtc() 변환 시 KST 기준 9시간이 빠지는 문제 수정
  - nextCursorCreatedAt을 String?으로 유지해 변환 없이 그대로 서버에 전달

  ### 스크롤 UX 개선

  - 상단 200px 진입 시 이전 메시지 자동 로드, 로드 완료 후 스크롤 위치 복원 (jumpTo(oldPixels + delta))
  - 이전 메시지 로드 중 상단에 소형 로딩 인디케이터 표시
  - 채팅방 진입 시 위→아래 스크롤 애니메이션 제거: 메시지 수 증가 시에만 스크롤 트리거하도록 개선 (_lastScrolledMessageCount 기반)


## Screenshot
<!--기능을 실행했을 때 정상 동작하는지 여부를 확인하고 스샷을 올려주세요  -->


## 💬 리뷰 요구사항(선택)
<!--리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요  
 고민사항도 적어주세요.  -->
